### PR TITLE
Move all user-chooses sections in one single section

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,195 +118,194 @@
         </li>
       </ul>
     </section>
-  </section>
-  <section id="mediadevices-interface">
-    <h3>MediaDevices Interface Extensions</h3>
-    <div>
-      <pre class="idl"
+    <section id="mediadevices-interface">
+      <h3>MediaDevices Interface Extensions</h3>
+      <div>
+        <pre class="idl"
 >partial interface MediaDevices {
   readonly attribute GetUserMediaSemantics defaultSemantics;
 };</pre>
-    </div>
-    <section>
-      <h2>Attributes</h2>
-      <dl data-link-for="MediaDevices" data-dfn-for="MediaDevices"
-      class="attributes">
-        <dt id="def-mediadevices-defaultSemantics"><dfn><code>defaultSemantics</code></dfn>
-        of type <span class="idlAttrType"><a>GetUserMediaSemantics</a></span>, readonly</dt>
-        <dd>
-          <p>The default semantics of {{MediaDevices/getUserMedia()}} in this
-          user agent.</p>
-          <p>User agents SHOULD default to <code>"browser-chooses"</code>
-          for backwards compatibility, until a transition plan has been
-          enacted where a majority of user agents collectively switch their
-          defaults to <code>"user-chooses"</code> for improved user privacy,
-          and usage metrics suggest this transition is feasible without
-          major breakage.</p>
-        </dd>
-      </dl>
-    </section>
-  </section>
-  <section id="mediastreamconstraints-dictionary-extensions">
-    <h3>MediaStreamConstraints dictionary extensions</h3>
-    <div>
-      <pre class="idl"
->partial dictionary MediaStreamConstraints {
-  GetUserMediaSemantics semantics;
-};</pre>
+      </div>
       <section>
-        <h2>Dictionary {{MediaStreamConstraints}} Members</h2>
-        <dl data-link-for="MediaStreamConstraints" data-dfn-for=
-        "MediaStreamConstraints" class="dictionary-members">
-          <dt><dfn><code>semantics</code></dfn> of type <span class=
-          "idlMemberType">{{GetUserMediaSemantics}}</span></dt>
+        <h2>Attributes</h2>
+        <dl data-link-for="MediaDevices" data-dfn-for="MediaDevices"
+        class="attributes">
+          <dt id="def-mediadevices-defaultSemantics"><dfn><code>defaultSemantics</code></dfn>
+          of type <span class="idlAttrType"><a>GetUserMediaSemantics</a></span>, readonly</dt>
           <dd>
-            <p>In cases where the specified constraints do not narrow
-            multiple choices between devices down to one per kind, specifies
-            how the final determination of which devices to pick from the
-            remaining choices MUST be made. If not specified, then the
-            <a data-link-for="MediaDevices">defaultSemantics</a> are used.
-            </p>
+            <p>The default semantics of {{MediaDevices/getUserMedia()}} in this
+            user agent.</p>
+            <p>User agents SHOULD default to <code>"browser-chooses"</code>
+            for backwards compatibility, until a transition plan has been
+            enacted where a majority of user agents collectively switch their
+            defaults to <code>"user-chooses"</code> for improved user privacy,
+            and usage metrics suggest this transition is feasible without
+            major breakage.</p>
           </dd>
         </dl>
       </section>
-    </div>
-  </section>
-  <section id="getusermediasemantics-enum">
-    <h3>GetUserMediaSemantics enum</h3>
-    <div>
-      <pre class="idl"
+    </section>
+    <section id="mediastreamconstraints-dictionary-extensions">
+      <h3>MediaStreamConstraints dictionary extensions</h3>
+      <div>
+        <pre class="idl"
+>partial dictionary MediaStreamConstraints {
+  GetUserMediaSemantics semantics;
+};</pre>
+        <section>
+          <h2>Dictionary {{MediaStreamConstraints}} Members</h2>
+          <dl data-link-for="MediaStreamConstraints" data-dfn-for=
+          "MediaStreamConstraints" class="dictionary-members">
+            <dt><dfn><code>semantics</code></dfn> of type <span class=
+            "idlMemberType">{{GetUserMediaSemantics}}</span></dt>
+            <dd>
+              <p>In cases where the specified constraints do not narrow
+              multiple choices between devices down to one per kind, specifies
+              how the final determination of which devices to pick from the
+              remaining choices MUST be made. If not specified, then the
+              <a data-link-for="MediaDevices">defaultSemantics</a> are used.
+              </p>
+            </dd>
+          </dl>
+        </section>
+      </div>
+    </section>
+    <section id="getusermediasemantics-enum">
+      <h3>GetUserMediaSemantics enum</h3>
+      <div>
+        <pre class="idl"
 >enum GetUserMediaSemantics {
   "browser-chooses",
   "user-chooses"
 };</pre>
-      <table data-link-for="GetUserMediaSemantics" data-dfn-for=
-      "GetUserMediaSemantics" class="simple">
-        <tbody>
-          <tr>
-            <th colspan="2"><dfn>GetUserMediaSemantics</dfn> Enumeration
-            description</th>
-          </tr>
-          <tr>
-            <td><dfn><code id=
-            "idl-def-GetUserMediaSemantics.browser-chooses">browser-chooses</code></dfn></td>
-            <td>
-              <p>When application-specified constraints do not narrow multiple
-              choices between devices down to one per kind, the user agent is
-              allowed to make the final determination between the remaining
-              choices.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td><dfn><code id=
-            "idl-def-GetUserMediaSemantics.user-chooses">user-chooses</code></dfn></td>
-            <td>
-              <p>When application-specified constraints do not narrow
-              multiple choices between devices down to one per kind, the user
-              agent MUST
-              <a href="prompt-the-user-to-choose">prompt the user to choose</a>
-              between the remaining choices, even if the application already
-              has permission to some or all of them.</p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </section>
-  <section>
-    <h2>Algorithms</h2>
-    <p>When the {{MediaDevices/getUserMedia()}} method is invoked, run the
-    following steps before invoking the {{MediaDevices/getUserMedia()}}
-    algorithm:</p>
-    <ol>
-        <li>
-          <p>Let <var>mediaDevices</var> be the object on which this method was
-          invoked.</p>
-        </li>
-        <li>
-          <p>Let <var>constraints</var> be the method's first argument.</p>
-        </li>
-        <li>
-          <p>Let <var>semanticsPresent</var> be <code>true</code> if
-          <var>constraints</var><code>.semantics</code> [= map/exists =],
-          otherwise <code>false</code>.</p>
-        </li>
-        <li>
-          <p>Let <var>semantics</var> be
-          <var>constraints</var><code>.semantics</code>
-          if <a href="https://heycam.github.io/webidl/#dfn-present">present</a>,
-          or the value of <var>mediaDevices</var><code>.<a data-link-for="MediaDevices">defaultSemantics</a></code>
-          otherwise.</p>
-        </li>
-        <li>
-          <p>Replace step 6.5.1. of the {{MediaDevices/getUserMedia()}}
-          algorithm in its entirety with the following two steps:</p>
-          <ol>
-            <li>
-              <p>Let <var>descriptor</var> be a {{PermissionDescriptor}}
-              with its {{PermissionDescriptor/name}} member set to the permission name
-              associated with <var>kind</var> (e.g. {{PermissionName/"camera"}} for
-              <code>"video"</code>, {{PermissionName/"microphone"}} for <code>"audio"</code>), and,
-              optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate
-              device's <var>deviceId</var>.</p>
-            </li>
-            <li>
-              <p>If the number of unique devices sourcing tracks of
-              media type <var>kind</var> in <var>candidateSet</var>
-              is greater than <code>1</code> and
-              <var>semantics</var> is <code>"user-chooses"</code>,
-              then <a>prompt the user to choose</a> a device with
-              <var>descriptor</var>, resulting in provided media.
-              Otherwise, <a>request permission to use</a> a
-              device with <var>descriptor</var>, while considering
-              all devices being attached to a live and
-              <a>same-permission</a> MediaStreamTrack in the current
-              [=browsing
-              context=] to mean having permission status {{PermissionState/"granted"}},
-              resulting in provided media.</p>
-              <p><dfn>Same-permission</dfn> in this context means a
-              {{MediaStreamTrack}} that required the same level of
-              permission to obtain as what is being requested.</p>
-              <p>When asking the user’s permission, the user agent
-              MUST disclose whether permission will be granted only to
-              the device chosen, or to all devices of that
-              <var>kind</var>.</p>
-              <p>Let <var>track</var> be the provided media, which
-              MUST be precisely one track of type <var>kind</var> from
-              <var>finalSet</var>. If <var>semantics</var> is
-              <code>"browser-chooses"</code> then the decision of
-              which track to choose from <var>finalSet</var> is up
-              to the User Agent, which MAY use the value of the computed
-              "fitness distance" from the <a href=
-              "https://www.w3.org/TR/mediacapture-streams/#dfn-selectsettings">
-              SelectSettings</a>
-              algorithm, the value of <var>semanticsPresent</var>,
-              or any other internally-available information about
-              the devices, as inputs to its decision.
-              If <var>semantics</var> is <code>"user-chooses"</code>,
-              and the application has not narrowed down the choices
-              to one, then the user agent MUST ask the user to make
-              the final selection.</p>
-              <p>Once selected, the source of the
-              {{MediaStreamTrack}} MUST NOT change.</p>
-              <p>User Agents are encouraged to default to or present
-              a default choice based primarily on fitness distance,
-              and secondarily on the user's primary or system default
-              device for <var>kind</var> (when possible). User Agents
-              MAY allow users to use any media source, including
-              pre-recorded media files.</p>
-            </li>
-          </ol>
-        </li>
-    </ol>
-  </section>
-  <section>
-    <h2>Examples</h2>
-    <div>
-      <p>This example shows a setup with a start button and a camera selector
-      using the new semantics (microphone is not shown for brievity but is
-      equivalent).</p>
-      <pre class="example">
+        <table data-link-for="GetUserMediaSemantics" data-dfn-for=
+        "GetUserMediaSemantics" class="simple">
+          <tbody>
+            <tr>
+              <th colspan="2"><dfn>GetUserMediaSemantics</dfn> Enumeration
+              description</th>
+            </tr>
+            <tr>
+              <td><dfn><code id=
+              "idl-def-GetUserMediaSemantics.browser-chooses">browser-chooses</code></dfn></td>
+              <td>
+                <p>When application-specified constraints do not narrow multiple
+                choices between devices down to one per kind, the user agent is
+                allowed to make the final determination between the remaining
+                choices.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td><dfn><code id=
+              "idl-def-GetUserMediaSemantics.user-chooses">user-chooses</code></dfn></td>
+              <td>
+                <p>When application-specified constraints do not narrow
+                multiple choices between devices down to one per kind, the user
+                agent MUST
+                <a href="prompt-the-user-to-choose">prompt the user to choose</a>
+                between the remaining choices, even if the application already
+                has permission to some or all of them.</p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+    <section>
+      <h2>Algorithms</h2>
+      <p>When the {{MediaDevices/getUserMedia()}} method is invoked, run the
+      following steps before invoking the {{MediaDevices/getUserMedia()}}
+      algorithm:</p>
+      <ol>
+          <li>
+            <p>Let <var>mediaDevices</var> be the object on which this method was
+            invoked.</p>
+          </li>
+          <li>
+            <p>Let <var>constraints</var> be the method's first argument.</p>
+          </li>
+          <li>
+            <p>Let <var>semanticsPresent</var> be <code>true</code> if
+            <var>constraints</var><code>.semantics</code> [= map/exists =],
+            otherwise <code>false</code>.</p>
+          </li>
+          <li>
+            <p>Let <var>semantics</var> be
+            <var>constraints</var><code>.semantics</code>
+            if <a href="https://heycam.github.io/webidl/#dfn-present">present</a>,
+            or the value of <var>mediaDevices</var><code>.<a data-link-for="MediaDevices">defaultSemantics</a></code>
+            otherwise.</p>
+          </li>
+          <li>
+            <p>Replace step 6.5.1. of the {{MediaDevices/getUserMedia()}}
+            algorithm in its entirety with the following two steps:</p>
+            <ol>
+              <li>
+                <p>Let <var>descriptor</var> be a {{PermissionDescriptor}}
+                with its {{PermissionDescriptor/name}} member set to the permission name
+                associated with <var>kind</var> (e.g. {{PermissionName/"camera"}} for
+                <code>"video"</code>, {{PermissionName/"microphone"}} for <code>"audio"</code>), and,
+                optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate
+                device's <var>deviceId</var>.</p>
+              </li>
+              <li>
+                <p>If the number of unique devices sourcing tracks of
+                media type <var>kind</var> in <var>candidateSet</var>
+                is greater than <code>1</code> and
+                <var>semantics</var> is <code>"user-chooses"</code>,
+                then <a>prompt the user to choose</a> a device with
+                <var>descriptor</var>, resulting in provided media.
+                Otherwise, <a>request permission to use</a> a
+                device with <var>descriptor</var>, while considering
+                all devices being attached to a live and
+                <a>same-permission</a> MediaStreamTrack in the current
+                [=browsing
+                context=] to mean having permission status {{PermissionState/"granted"}},
+                resulting in provided media.</p>
+                <p><dfn>Same-permission</dfn> in this context means a
+                {{MediaStreamTrack}} that required the same level of
+                permission to obtain as what is being requested.</p>
+                <p>When asking the user’s permission, the user agent
+                MUST disclose whether permission will be granted only to
+                the device chosen, or to all devices of that
+                <var>kind</var>.</p>
+                <p>Let <var>track</var> be the provided media, which
+                MUST be precisely one track of type <var>kind</var> from
+                <var>finalSet</var>. If <var>semantics</var> is
+                <code>"browser-chooses"</code> then the decision of
+                which track to choose from <var>finalSet</var> is up
+                to the User Agent, which MAY use the value of the computed
+                "fitness distance" from the <a href=
+                "https://www.w3.org/TR/mediacapture-streams/#dfn-selectsettings">
+                SelectSettings</a>
+                algorithm, the value of <var>semanticsPresent</var>,
+                or any other internally-available information about
+                the devices, as inputs to its decision.
+                If <var>semantics</var> is <code>"user-chooses"</code>,
+                and the application has not narrowed down the choices
+                to one, then the user agent MUST ask the user to make
+                the final selection.</p>
+                <p>Once selected, the source of the
+                {{MediaStreamTrack}} MUST NOT change.</p>
+                <p>User Agents are encouraged to default to or present
+                a default choice based primarily on fitness distance,
+                and secondarily on the user's primary or system default
+                device for <var>kind</var> (when possible). User Agents
+                MAY allow users to use any media source, including
+                pre-recorded media files.</p>
+              </li>
+            </ol>
+          </li>
+      </ol>
+    </section>
+    <section>
+      <h2>Examples</h2>
+      <div>
+        <p>This example shows a setup with a start button and a camera selector
+        using the new semantics (microphone is not shown for brievity but is
+        equivalent).</p>
+        <pre class="example">
 &lt;button id="start"&gt;Start&lt;/button&gt;
 &lt;button id="chosenCamera" disabled&gt;Camera: none&lt;/button&gt;
 &lt;script&gt;
@@ -344,8 +343,9 @@ function setCameraTrack(track) {
   chosenCamera.disabled = false;
 }
 &lt;/script&gt;
-      </pre>
-    </div>
+        </pre>
+      </div>
+    </section>
   </section>
 </body>
 </html>


### PR DESCRIPTION
This will allow to have one section per extension.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-extensions/pull/22.html" title="Last updated on May 3, 2021, 1:21 PM UTC (e5f3ea4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/22/43e3ff8...youennf:e5f3ea4.html" title="Last updated on May 3, 2021, 1:21 PM UTC (e5f3ea4)">Diff</a>