### PR TITLE
Add support for MediaStreamTrack being Serializable

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,22 +370,16 @@ partial interface MediaStreamTrack {
 };</pre>
     </div>
     <div>
-      <p>At creation of a {{MediaStreamTrack}} object, called <var>track</var>, run the following steps:</p>
+      <p>The {{MediaStreamTrack}} <a data-cite="!HTML/#serialization-steps">serialization steps</a>, given <var>value</var>, <var>dataHolder</var>, and <var>forStorage</var> are:</p>
       <ol>
-        <li><p>Initialize <var>track</var>.`[[IsDetached]]` to <code>false</code>.</p></li>
-      </ol>
-    </div>
-    <div>
-      <p>The {{MediaStreamTrack}} <a data-cite="!HTML/#serialization-steps">transfer steps</a>, given <var>value</var> and <var>dataHolder</var>, are:</p>
-      <ol>
-        <li><p>If <var>value</var>.`[[IsDetached]]` is <code>true</code>, throw a "DataCloneError" DOMException.</p></li>
+        <li><p>If <var>forStorage</var> is <code>true</code>, throw a "DataCloneError" DOMException.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[id]]` to <var>value</var>.{{MediaStreamTrack/id}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[kind]]` to <var>value</var>.{{MediaStreamTrack/kind}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[label]]` to <var>value</var>.{{MediaStreamTrack/label}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[readyState]]` to <var>value</var>.{{MediaStreamTrack/readyState}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[enabled]]` to <var>value</var>.{{MediaStreamTrack/enabled}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[muted]]` to <var>value</var>.{{MediaStreamTrack/muted}}.</p></li>
-        <li><p>Set <var>dataHolder</var>.`[[source]]` to <var>value</var> underlying source.</p></li>
+        <li><p>Set <var>dataHolder</var>.`[[source]]` to reference <var>value</var>'s underlying source.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[constraints]]` to <var>value</var> active constraints.</p></li>
       </ol>
     </div>
@@ -397,10 +391,17 @@ partial interface MediaStreamTrack {
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/readyState}} to <var>dataHolder</var>.`[[readyState]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/enabled}} to <var>dataHolder</var>.`[[enabled]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/muted}} to <var>dataHolder</var>.`[[muted]]`.</p></li>
-        <li><p>Initialize <var>track</var> underlying source to <var>dataHolder</var>.`[[source]]`.</p></li>
+        <li><p>Initialize <var>track</var> underlying source to the source referenced by <var>dataHolder</var>.`[[source]]`.</p></li>
         <li><p>Set <var>track</var>'s constraints to <var>dataHolder</var>.`[[constraints]]`.</p></li>
       </ol>
     </div>
+    <p>
+      The serialization of a MediaStreamTrack cannot be persisted to storage.
+    </p>
+    <p class="note">
+      The underlying source of a MediaStreamTrack is a reference to the source. Serialization and deserialization does
+      not create a new source, but rather passes a reference to it. The form of the reference is not JS-visible.
+    </p>
   </section>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@ partial interface MediaStreamTrack {
         <li><p>Set <var>dataHolder</var>.`[[enabled]]` to <var>value</var>.{{MediaStreamTrack/enabled}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[muted]]` to <var>value</var>.{{MediaStreamTrack/muted}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[source]]` to reference <var>value</var>'s underlying source.</p></li>
-        <li><p>Set <var>dataHolder</var>.`[[constraints]]` to <var>value</var> active constraints.</p></li>
+        <li><p>Set <var>dataHolder</var>.`[[constraints]]` to <var>value</var>.`[[Constraints]]`.</p></li>
       </ol>
     </div>
     <div><p>{{MediaStreamTrack}} <a data-cite="!HTML/#deserialization-steps">deserialization steps</a>, given <var>dataHolder</var> and <var>track</var>, are:</p>
@@ -392,7 +392,7 @@ partial interface MediaStreamTrack {
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/enabled}} to <var>dataHolder</var>.`[[enabled]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/muted}} to <var>dataHolder</var>.`[[muted]]`.</p></li>
         <li><p>Initialize <var>track</var> underlying source to the source referenced by <var>dataHolder</var>.`[[source]]`.</p></li>
-        <li><p>Set <var>track</var>'s constraints to <var>dataHolder</var>.`[[constraints]]`.</p></li>
+        <li><p>Initialize <var>track</var>.`[[Constraints]]` to <var>dataHolder</var>.`[[constraints]]`.</p></li>
       </ol>
     </div>
     <p>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
   var respecConfig = {
     group: "webrtc",
-    xref: ["html", "infra", "permissions", "dom", "mediacapture-streams", "webidl"],
+    xref: ["html", "infra", "permissions", "dom", "mediacapture-streams", "webaudio", "webidl"],
     edDraftURI: "https://w3c.github.io/mediacapture-extensions/",
     editors:  [
       {name: "Jan-Ivar Bruaroey", company: "Mozilla Corporation", w3cid: 79152},
@@ -347,5 +347,61 @@ function setCameraTrack(track) {
       </pre>
     </div>
   </section>
+  <section>
+    <h2>Serializable MediaStreamTrack</h2>
+    <div>
+      <p>A {{MediaStreamTrack}} is a <a data-cite="!HTML/#serializable-objects">serializable object</a>.
+      This allows manipulating real-time media outside the context it was requested or created in, for instance in workers or third-party iframes.</p>
+      <p>
+        To preserve the existing privacy and security infrastructure, in particular for capture tracks,
+        a transferred track remains tightly bound to the original source.</p>
+      <p>
+        In particular, for the case of cameras and microphones, which are tightly bound to their original context, any track that
+        is bound to that source will be ended immediately when that context goes away.
+      </p>
+    </div>
+    <div>
+      <p>The WebIDL changes are the following:
+      <pre class="idl"
+>[Exposed=(Window,Worker,AudioWorklet), Serializable]
+partial interface MediaStreamTrack {
+// Remove partial once we figure out how to do it without creating respec warnings.
+// No change to MediaStreamTrack exposed API.
+};</pre>
+    </div>
+    <div>
+      <p>At creation of a {{MediaStreamTrack}} object, called <var>track</var>, run the following steps:</p>
+      <ol>
+        <li><p>Initialize <var>track</var>.`[[IsDetached]]` to <code>false</code>.</p></li>
+      </ol>
+    </div>
+    <div>
+      <p>The {{MediaStreamTrack}} <a data-cite="!HTML/#serialization-steps">transfer steps</a>, given <var>value</var> and <var>dataHolder</var>, are:</p>
+      <ol>
+        <li><p>If <var>value</var>.`[[IsDetached]]` is <code>true</code>, throw a "DataCloneError" DOMException.</p></li>
+        <li><p>Set <var>dataHolder</var>.`[[id]]` to <var>value</var>.{{MediaStreamTrack/id}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.`[[kind]]` to <var>value</var>.{{MediaStreamTrack/kind}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.`[[label]]` to <var>value</var>.{{MediaStreamTrack/label}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.`[[readyState]]` to <var>value</var>.{{MediaStreamTrack/readyState}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.`[[enabled]]` to <var>value</var>.{{MediaStreamTrack/enabled}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.`[[muted]]` to <var>value</var>.{{MediaStreamTrack/muted}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.`[[source]]` to <var>value</var> underlying source.</p></li>
+        <li><p>Set <var>dataHolder</var>.`[[constraints]]` to <var>value</var> active constraints.</p></li>
+      </ol>
+    </div>
+    <div><p>{{MediaStreamTrack}} <a data-cite="!HTML/#deserialization-steps">deserialization steps</a>, given <var>dataHolder</var> and <var>track</var>, are:</p>
+      <ol>
+        <li><p>Initialize <var>track</var>.{{MediaStreamTrack/id}} to <var>dataHolder</var>.`[[id]]`.</p></li>
+        <li><p>Initialize <var>track</var>.{{MediaStreamTrack/kind}} to <var>dataHolder</var>.`[[kind]]`.</p></li>
+        <li><p>Initialize <var>track</var>.{{MediaStreamTrack/label}} to <var>dataHolder</var>.`[[label]]`.</p></li>
+        <li><p>Initialize <var>track</var>.{{MediaStreamTrack/readyState}} to <var>dataHolder</var>.`[[readyState]]`.</p></li>
+        <li><p>Initialize <var>track</var>.{{MediaStreamTrack/enabled}} to <var>dataHolder</var>.`[[enabled]]`.</p></li>
+        <li><p>Initialize <var>track</var>.{{MediaStreamTrack/muted}} to <var>dataHolder</var>.`[[muted]]`.</p></li>
+        <li><p>Initialize <var>track</var> underlying source to <var>dataHolder</var>.`[[source]]`.</p></li>
+        <li><p>Set <var>track</var>'s constraints to <var>dataHolder</var>.`[[constraints]]`.</p></li>
+      </ol>
+    </div>
+  </section>
 </body>
 </html>
+


### PR DESCRIPTION
Alternative to #21 
Fixes #16


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/pull/24.html" title="Last updated on May 20, 2021, 11:20 AM UTC (dc11b76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/24/43e3ff8...dc11b76.html" title="Last updated on May 20, 2021, 11:20 AM UTC (dc11b76)">Diff</a>