### PR TITLE
Remove unneeded comments and AudioWorklet exposure

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,10 +359,8 @@ function setCameraTrack(track) {
     <div>
       <p>The WebIDL changes are the following:
       <pre class="idl"
->[Exposed=(Window,Worker,AudioWorklet), Transferable]
+>[Exposed=(Window,Worker), Transferable]
 partial interface MediaStreamTrack {
-// Remove partial once we figure out how to do it without creating respec warnings.
-// No change to MediaStreamTrack exposed API.
 };</pre>
     </div>
     <div>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-extensions/pull/28.html" title="Last updated on Jun 10, 2021, 8:23 AM UTC (d8c6844)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/28/0846b9c...youennf:d8c6844.html" title="Last updated on Jun 10, 2021, 8:23 AM UTC (d8c6844)">Diff</a>