### PR TITLE
Update MediaStreamTrack related links according https://github.com/w3c/mediacapture-main/pull/818

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,8 +408,8 @@ partial interface MediaStreamTrack {
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/readyState}} to <var>dataHolder</var>.`[[readyState]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/enabled}} to <var>dataHolder</var>.`[[enabled]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/muted}} to <var>dataHolder</var>.`[[muted]]`.</p></li>
-        <li><p>[=Initialize the underlying source=] of <var>track</var> to <var>dataHolder</var>.`[[source]]` with
-          {{MediaStreamTrack/tieSourceToContext}} equal to <code>false</code>.</p></li>
+        <li><p>[=MediaStreamTrack/Initialize the underlying source=] of <var>track</var> to <var>dataHolder</var>.`[[source]]` with
+          [=MediaStreamTrack/Initialize the underlying source/tieSourceToContext=] equal to <code>false</code>.</p></li>
         <li><p>Set <var>track</var>'s constraints to <var>dataHolder</var>.`[[constraints]]`.</p></li>
       </ol>
     </div>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-extensions/issues/33 (or at least part of it).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-extensions/pull/34.html" title="Last updated on Sep 2, 2021, 7:56 AM UTC (4d48269)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/34/5129c07...youennf:4d48269.html" title="Last updated on Sep 2, 2021, 7:56 AM UTC (4d48269)">Diff</a>