### PR TITLE
Replace GETUSERMEDIA by mediacapture-streams

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 
 <body>
   <section id="abstract">
-    <p>This document defines a set of ECMAScript APIs in WebIDL to extend the [[GETUSERMEDIA]] specification.</p>
+    <p>This document defines a set of ECMAScript APIs in WebIDL to extend the [[mediacapture-streams]] specification.</p>
   </section>
   <section id="sotd">
     <p>This is an unofficial proposal.</p>
@@ -32,7 +32,7 @@
   <section id="introduction">
     <h2>Introduction</h2>
     <p>This document contains proposed extensions and modifications to the
-    [[GETUSERMEDIA]] specification.</p>
+    [[mediacapture-streams]] specification.</p>
     <p>New features and modifications to existing features proposed here may be
     considered for addition into the main specification post Recommendation.
     Deciding factors will include maturity of the extension or modification,
@@ -51,7 +51,7 @@
     <p>
       This document uses the definitions {{MediaDevices}}, {{MediaStreamTrack}},
       {{MediaStreamConstraints}} and {{ConstrainablePattern}}
-      from [[!GETUSERMEDIA]].
+      from [[!mediacapture-streams]].
       <p>The terms [=permission state=], [=request permission to use=], and
       <a data-cite="permissions">prompt the user to choose</a> are defined in
       [[!permissions]].</p>    </p>
@@ -397,7 +397,7 @@ partial interface MediaStreamTrack {
         <li><p>Set <var>dataHolder</var>.`[[source]]` to <var>value</var> underlying source.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[constraints]]` to <var>value</var> active constraints.</p></li>
         <li><p>Set <var>value</var>.`[[IsDetached]]` to <code>true</code>.</p></li>
-        <li><p>Set <var>value</var>.{{MediaStreamTrack/readyState}} to <a data-cite="!GETUSERMEDIA/#track-ended">"ended"</a>.</p></li>
+        <li><p>Set <var>value</var>.{{MediaStreamTrack/readyState}} to <a data-cite="!mediacapture-streams/#track-ended">"ended"</a>.</p></li>
       </ol>
     </div>
     <div><p>{{MediaStreamTrack}} <a data-cite="!HTML/#transfer-receiving-steps">transfer-receiving steps</a>, given <var>dataHolder</var> and <var>track</var>, are:</p>


### PR DESCRIPTION
We already define mediacapture-streams in spec preamble


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-extensions/pull/35.html" title="Last updated on Sep 2, 2021, 12:50 PM UTC (9677c12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/35/5129c07...youennf:9677c12.html" title="Last updated on Sep 2, 2021, 12:50 PM UTC (9677c12)">Diff</a>