### PR TITLE
Transferable MediaStreamTrack: clarify setting readyState

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@ partial interface MediaStreamTrack {
         <li><p>Set <var>dataHolder</var>.`[[source]]` to <var>value</var> underlying source.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[constraints]]` to <var>value</var> active constraints.</p></li>
         <li><p>Set <var>value</var>.`[[IsDetached]]` to <code>true</code>.</p></li>
-        <li><p>Set <var>value</var>.{{MediaStreamTrack/readyState}} to <a data-cite="!mediacapture-streams/#track-ended">"ended"</a>.</p></li>
+        <li><p>Set <var>value</var>.{{MediaStreamTrack/[[ReadyState]]}} to <a data-cite="!mediacapture-streams/#track-ended">"ended"</a> (without stopping the underlying source or firing an `ended` event).</p></li>
       </ol>
     </div>
     <div><p>{{MediaStreamTrack}} <a data-cite="!HTML/#transfer-receiving-steps">transfer-receiving steps</a>, given <var>dataHolder</var> and <var>track</var>, are:</p>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dogben/mediacapture-extensions/pull/50.html" title="Last updated on Jan 21, 2022, 10:56 AM UTC (978467e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/50/799b509...dogben:978467e.html" title="Last updated on Jan 21, 2022, 10:56 AM UTC (978467e)">Diff</a>