### PR TITLE
Eye contact correction

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,5 +418,115 @@ partial interface MediaStreamTrack {
       In a sense, between these steps, the data holder is attached to the underlying source as if it was a track.</p>
     </div>
   </section>
+  <section>
+    <h2>Eye contact correction</h2>
+    <section>
+      <h3>{{MediaTrackSupportedConstraints}}</h3>
+      <pre class="idl"
+>partial dictionary MediaTrackSupportedConstraints {
+  boolean eyeContactCorrection = true;
+};</pre>
+      <section class="notoc">
+        <h4>Dictionary {{MediaTrackSupportedConstraints}} Members</h4>
+        <dl class="dictionary-members" data-dfn-for="MediaTrackSupportedConstraints" data-link-for="MediaTrackSupportedConstraints">
+          <dt><dfn><code>eyeContactCorrection</code></dfn> of type <span class="idlMemberType">{{boolean}}</span>, defaulting to <code>true</code></dt>
+          <dd>
+            <p>Whether <a>eye contact correction</a> constraining is
+            recognized.</p>
+          </dd>
+        </dl>
+      </section>
+    </section>
+    <section>
+      <h3>{{MediaTrackCapabilities}}</h3>
+      <pre class="idl"
+>partial dictionary MediaTrackCapabilities {
+  sequence&lt;boolean&gt; eyeContactCorrection;
+};</pre>
+      <section class="notoc">
+        <h4>Dictionary {{MediaTrackCapabilities}} Members</h4>
+        <dl class="dictionary-members" data-dfn-for="MediaTrackCapabilities" data-link-for="MediaTrackCapabilities">
+          <dt><dfn><code>eyeContactCorrection</code></dfn> of type <span class="idlMemberType">sequence&lt;{{boolean}}&gt;</span></dt>
+          <dd>
+            <p>A sequence of supported <a>eye contact correction</a> modes.
+            If the source cannot do eye contact correction,
+            a single <code>false</code> is reported.
+            If the eye contact correction cannot be turned off,
+            a single <code>true</code> is reported.
+            If the script can control the eye contact correction,
+            both <code>false</code> and <code>true</code> are reported as
+            possible values.</p>
+          </dd>
+        </dl>
+      </section>
+    </section>
+    <section>
+      <h3>{{MediaTrackConstraintSet}}</h3>
+      <pre class="idl"
+>partial dictionary MediaTrackConstraintSet {
+  ConstrainBoolean eyeContactCorrection;
+};</pre>
+      <section class="notoc">
+        <h4>Dictionary {{MediaTrackConstraintSet}} Members</h4>
+        <dl class="dictionary-members" data-dfn-for="MediaTrackConstraintSet" data-link-for="MediaTrackConstraintSet">
+          <dt><dfn><code>eyeContactCorrection</code></dfn> of type <span class="idlMemberType">{{ConstrainBoolean}}</span></dt>
+          <dd>
+            <p>See <a>eye contact correction</a> constrainable property.</p>
+          </dd>
+        </dl>
+      </section>
+    </section>
+    <section>
+      <h3>{{MediaTrackSettings}}</h3>
+      <pre class="idl"
+>partial dictionary MediaTrackSettings {
+  boolean eyeContactCorrection;
+};</pre>
+      <section class="notoc">
+        <h4>Dictionary {{MediaTrackSettings}} Members</h4>
+        <dl class="dictionary-members" data-dfn-for="MediaTrackSettings" data-link-for="MediaTrackSettings">
+          <dt><dfn><code>eyeContactCorrection</code></dfn> of type <span class="idlMemberType">{{boolean}}</span></dt>
+          <dd>
+            <p>Current <a>eye contact correction</a> setting.</p>
+          </dd>
+        </dl>
+      </section>
+    </section>
+    <section>
+      <h3>Constrainable Properties</h3>
+      <ol>
+        <li>
+          <p><dfn>Eye contact correction</dfn> is a boolean setting
+          controlling whether the eye contact is to be corrected.</p>
+        </li>
+      </ol>
+    </section>
+    <section>
+      <h3>Examples</h3>
+      <pre class="example">
+&lt;video&gt;&lt;/video&gt;
+&lt;script&gt;
+// Open camera.
+const stream = await navigator.mediaDevices.getUserMedia({video: true});
+const [videoTrack] = stream.getVideoTracks();
+
+// Try to correct eye contact.
+const videoCapabilities = videoTrack.getCapabilities();
+if ((videoCapabilities.eyeContactCorrection || []).includes(true)) {
+  await videoTrack.applyConstraints({
+    advanced: [{eyeContactCorrection: true}]
+  });
+} else {
+  // Eye contact correction is not supported by the platform or by the camera.
+  // Consider falling back to some other method.
+}
+
+// Show to user.
+const videoElement = document.querySelector("video");
+videoElement.srcObject = stream;
+&lt;/script&gt;
+      </pre>
+    </section>
+  </section>
 </body>
 </html>


### PR DESCRIPTION
Eye contact correction corrects the eye contact then a user is looking at the display and not the camera while the camera is far from the point the user is looking at. This problem is widespread especially with large displays. For an example and background, see https://github.com/w3c/mediacapture-extensions/issues/46.

Please see https://github.com/w3c/mediacapture-extensions/pull/49#issue-1099641483 why a constrainable property is most suitable for the purpose.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eehakkin/intel-w3c-mediacapture-extensions/pull/52.html" title="Last updated on Jan 26, 2022, 2:45 PM UTC (c8529e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/52/799b509...eehakkin:c8529e1.html" title="Last updated on Jan 26, 2022, 2:45 PM UTC (c8529e1)">Diff</a>