### PR TITLE
Add powerEfficientPixelFormat

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,8 +50,8 @@
     <h2>Terminology</h2>
     <p>
       This document uses the definitions {{MediaDevices}}, {{MediaStreamTrack}},
-      {{MediaStreamConstraints}} and {{ConstrainablePattern}}
-      from [[!mediacapture-streams]].
+      {{MediaStreamConstraints}}, {{ConstrainablePattern}} and
+      {{ConstrainBoolean}} from [[!mediacapture-streams]].
       <p>The terms [=permission state=], [=request permission to use=], and
       <a data-cite="permissions">prompt the user to choose</a> are defined in
       [[!permissions]].</p>    </p>
@@ -206,6 +206,31 @@
             </tr>
           </tbody>
         </table>
+      </div>
+    </section>
+    <section id="mediastreamconstraints-dictionary-extensions">
+      <h3>MediaTrackConstraintSet dictionary extensions</h3>
+      <div>
+        <pre class="idl"
+>partial dictionary MediaTrackConstraintSet {
+  ConstrainBoolean efficientPixelFormat;
+};</pre>
+        <section>
+          <h2>Dictionary {{MediaTrackConstraintSet}} Members</h2>
+          <dl data-link-for="MediaTrackConstraintSet" data-dfn-for=
+          "MediaTrackConstraintSet" class="dictionary-members">
+            <dt><dfn><code>efficientPixelFormat</code></dfn> of type <span class=
+            "idlMemberType">{{ConstrainBoolean}}</span></dt>
+            <dd>
+              <p>It is common for cameras to support different pixel formats for
+              different resolutions and frame rates. The user agent SHOULD label
+              pixel formats that incur significant performance penalty as
+              "inefficient". What format is or is not considered inefficient is
+              up to the user agent, but software decoding MJPEG in FullHD might
+              be an example of an inefficient path.</p>
+            </dd>
+          </dl>
+        </section>
       </div>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -210,6 +210,9 @@
         </table>
       </div>
     </section>
+  </section>
+  <section id="additional constraints">
+    <h2>Additional constraints</h2>
     <section id="mediatracksupportedconstraints-dictionary-extensions">
       <h3>MediaTrackSupportedConstraints dictionary extensions</h3>
       <div>

--- a/index.html
+++ b/index.html
@@ -211,8 +211,8 @@
       </div>
     </section>
   </section>
-  <section id="additional constraints">
-    <h2>Additional constraints</h2>
+  <section id="the powerEfficientPixelFormat constraint">
+    <h2>The powerEfficientPixelFormat constraint</h2>
     <section id="mediatracksupportedconstraints-dictionary-extensions">
       <h3>MediaTrackSupportedConstraints dictionary extensions</h3>
       <div>

--- a/index.html
+++ b/index.html
@@ -50,8 +50,9 @@
     <h2>Terminology</h2>
     <p>
       This document uses the definitions {{MediaDevices}}, {{MediaStreamTrack}},
-      {{MediaStreamConstraints}}, {{ConstrainablePattern}} and
-      {{ConstrainBoolean}} from [[!mediacapture-streams]].
+      {{MediaStreamConstraints}}, {{ConstrainablePattern}},
+      {{MediaTrackConstraintSet}} and {{ConstrainBoolean}} from
+      [[!mediacapture-streams]].
       <p>The terms [=permission state=], [=request permission to use=], and
       <a data-cite="permissions">prompt the user to choose</a> are defined in
       [[!permissions]].</p>    </p>

--- a/index.html
+++ b/index.html
@@ -52,9 +52,8 @@
       This document uses the definitions {{MediaDevices}}, {{MediaStreamTrack}},
       {{MediaStreamConstraints}}, {{ConstrainablePattern}},
       {{MediaTrackSupportedConstraints}}, {{MediaTrackCapabilities}},
-      {{MediaTrackConstraintSet}}, {{MediaTrackSettings}},
-      <a data-cite="mediacapture-streams">allowed required constraints for device selection</a>
-      and {{ConstrainBoolean}} from [[!mediacapture-streams]].
+      {{MediaTrackConstraintSet}}, {{MediaTrackSettings}} and
+      {{ConstrainBoolean}} from [[!mediacapture-streams]].
       <p>The terms [=permission state=], [=request permission to use=], and
       <a data-cite="permissions">prompt the user to choose</a> are defined in
       [[!permissions]].</p>    </p>
@@ -279,9 +278,7 @@
       </div>
     </section>
       <h2>Constrainable Properties</h2>
-      <h3>Additions to Constrainable Properties</h3>
-      <p>The names of constrainable properties in this document are defined
-      below.</p>
+      <p>The constrainable properties in this document are defined below.</p>
       <table class="simple">
         <thead>
           <tr>
@@ -305,11 +302,6 @@
           </tr>
         </tbody>
       </table>
-      <h3>Additions to allowed required constraints for device selection</h3>
-      <p>The following constrainable properties are
-      <a data-cite="mediacapture-streams">allowed required constraints for device selection</a>:
-      <a>avoidInefficientCompressedPixelFormat</a>.
-      </p>
     </section>
     <section>
       <h2>Algorithms</h2>

--- a/index.html
+++ b/index.html
@@ -293,11 +293,16 @@
             avoidInefficientCompressedPixelFormat</dfn></td>
             <td>{{ConstrainBoolean}}</td>
             <td>
-              <p>Compressed pixel formats need to be decoded. The user agent
-              SHOULD label compressed pixel formats that incur significant power
-              penalty when decoded as not power efficient. The labeling is up to
-              the user agent, but decoding MJPEG in software is an example of an
-              expensive mode.</p>
+              <p>Compressed pixel formats often need to be decoded, for instance
+              for display purposes or when being encoded during a video call.
+              The user agent SHOULD label compressed pixel formats that incur
+              significant power penalty when decoded as inefficient. The
+              labeling is up to the user agent, but decoding MJPEG in software
+              is an example of an expensive mode.</p>
+              <p>As a constraint, setting this to true can be used to filter out
+              inefficient modes, and not specifying a value is the same as
+              setting it to false. As a setting, this reflects whether or not
+              an inefficient mode is currently avoided.</p>
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -209,26 +209,26 @@
         </table>
       </div>
     </section>
-    <section id="mediastreamconstraints-dictionary-extensions">
+    <section id="mediatrackconstraintset-dictionary-extensions">
       <h3>MediaTrackConstraintSet dictionary extensions</h3>
       <div>
         <pre class="idl"
 >partial dictionary MediaTrackConstraintSet {
-  ConstrainBoolean efficientPixelFormat;
+  ConstrainBoolean powerEfficient;
 };</pre>
         <section>
           <h2>Dictionary {{MediaTrackConstraintSet}} Members</h2>
           <dl data-link-for="MediaTrackConstraintSet" data-dfn-for=
           "MediaTrackConstraintSet" class="dictionary-members">
-            <dt><dfn><code>efficientPixelFormat</code></dfn> of type <span class=
+            <dt><dfn><code>powerEfficient</code></dfn> of type <span class=
             "idlMemberType">{{ConstrainBoolean}}</span></dt>
             <dd>
-              <p>It is common for cameras to support different pixel formats for
-              different resolutions and frame rates. The user agent SHOULD label
-              pixel formats that incur significant performance penalty as
-              "inefficient". What format is or is not considered inefficient is
-              up to the user agent, but software decoding MJPEG in FullHD might
-              be an example of an inefficient path.</p>
+              <p>Some capture modes are more expensive than others when it comes
+              to power consumption. The user agent SHOULD label modes that incur
+              significant power penalty as not power efficient. What format is
+              or is not considered power efficient is up to the user agent, but
+              modes that cause software MJPEG decode are examples of expensive
+              modes.</p>
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -215,17 +215,17 @@
       <div>
         <pre class="idl"
 >partial dictionary MediaTrackSupportedConstraints {
-  boolean avoidInefficientCompressedPixelFormat = true;
+  boolean powerEfficientPixelFormat = true;
 };</pre>
         <section>
           <h2>Dictionary {{MediaTrackSupportedConstraints}} Members</h2>
           <dl data-link-for="MediaTrackSupportedConstraints" data-dfn-for=
           "MediaTrackSupportedConstraints" class="dictionary-members">
-            <dt><dfn>avoidInefficientCompressedPixelFormat</dfn> of type
+            <dt><dfn>powerEfficientPixelFormat</dfn> of type
             {{boolean}}, defaulting to <code>true</code></dt>
             <dd>See <a href=
-            "#def-constraint-avoidInefficientCompressedPixelFormat">
-            avoidInefficientCompressedPixelFormat</a> for details.</dd>
+            "#def-constraint-powerEfficientPixelFormat">
+            powerEfficientPixelFormat</a> for details.</dd>
           </dl>
         </section>
       </div>
@@ -235,23 +235,23 @@
       <div>
         <pre class="idl"
 >partial dictionary MediaTrackCapabilities {
-  sequence&lt;boolean&gt; avoidInefficientCompressedPixelFormat;
+  sequence&lt;boolean&gt; powerEfficientPixelFormat;
 };</pre>
         <section>
           <h2>Dictionary {{MediaTrackCapabilities}} Members</h2>
           <dl data-link-for="MediaTrackCapabilities" data-dfn-for=
           "MediaTrackCapabilities" class="dictionary-members">
-            <dt><dfn>avoidInefficientCompressedPixelFormat</dfn> of type
+            <dt><dfn>powerEfficientPixelFormat</dfn> of type
             <code>sequence&lt;{{boolean}}&gt;</code></dt>
             <dd>
-              <p>If the source has no inefficient compressed pixel formats, a
-              single <code>true</code> is reported. If the source only has
-              inefficient compressed pixel formats, a single <code>false</code>
-              is reported. If the script can control the feature, the source
+              <p>If the source only has power efficient pixel formats, a single
+              <code>true</code> is reported. If the source only has power
+              inefficient pixel formats, a single <code>false</code> is
+              reported. If the script can control the feature, the source
               reports a list with both <code>true</code> and <code>false</code>
               as possible values. See <a href=
-              "#def-constraint-avoidInefficientCompressedPixelFormat">
-              avoidInefficientCompressedPixelFormat</a> for additional
+              "#def-constraint-powerEfficientPixelFormat">
+              powerEfficientPixelFormat</a> for additional
               details.</p>
             </dd>
           </dl>
@@ -263,17 +263,17 @@
       <div>
         <pre class="idl"
 >partial dictionary MediaTrackSettings {
-  boolean avoidInefficientCompressedPixelFormat;
+  boolean powerEfficientPixelFormat;
 };</pre>
         <section>
           <h2>Dictionary {{MediaTrackSettings}} Members</h2>
           <dl data-link-for="MediaTrackSettings" data-dfn-for=
           "MediaTrackSettings" class="dictionary-members">
-            <dt><dfn>avoidInefficientCompressedPixelFormat</dfn> of type
+            <dt><dfn>powerEfficientPixelFormat</dfn> of type
             {{boolean}}</dt>
             <dd>See <a href=
-            "#def-constraint-avoidInefficientCompressedPixelFormat">
-            avoidInefficientCompressedPixelFormat</a> for details.</dd>
+            "#def-constraint-powerEfficientPixelFormat">
+            powerEfficientPixelFormat</a> for details.</dd>
       </section>
       </div>
     </section>
@@ -289,20 +289,23 @@
         </thead>
         <tbody>
           <tr>
-            <td><dfn id="def-constraint-avoidInefficientCompressedPixelFormat">
-            avoidInefficientCompressedPixelFormat</dfn></td>
+            <td><dfn id="def-constraint-powerEfficientPixelFormat">
+              powerEfficientPixelFormat</dfn></td>
             <td>{{ConstrainBoolean}}</td>
             <td>
               <p>Compressed pixel formats often need to be decoded, for instance
               for display purposes or when being encoded during a video call.
               The user agent SHOULD label compressed pixel formats that incur
-              significant power penalty when decoded as inefficient. The
+              significant power penalty when decoded as power inefficient. The
               labeling is up to the user agent, but decoding MJPEG in software
-              is an example of an expensive mode.</p>
-              <p>As a constraint, setting this to true can be used to filter out
-              inefficient modes, and not specifying a value is the same as
-              setting it to false. As a setting, this reflects whether or not
-              an inefficient mode is currently avoided.</p>
+              is an example of an expensive mode. Pixel formats that have not
+              been labeled power inefficient by the user agent are for the
+              purpose of this API considered power efficient.</p>
+              <p>As a constraint, setting it to true allows filtering out
+              inefficient pixel formats and setting it to false allows filtering
+              out efficient pixel formats.</p>
+              <p>As a setting, this reflects whether or not the current pixel
+              format is considered power efficient by the user agent.</p>
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -214,21 +214,20 @@
       <div>
         <pre class="idl"
 >partial dictionary MediaTrackConstraintSet {
-  ConstrainBoolean powerEfficient;
+  ConstrainBoolean avoidInefficientCompressedPixelFormat;
 };</pre>
         <section>
           <h2>Dictionary {{MediaTrackConstraintSet}} Members</h2>
           <dl data-link-for="MediaTrackConstraintSet" data-dfn-for=
           "MediaTrackConstraintSet" class="dictionary-members">
-            <dt><dfn><code>powerEfficient</code></dfn> of type <span class=
-            "idlMemberType">{{ConstrainBoolean}}</span></dt>
+            <dt><dfn><code>avoidInefficientCompressedPixelFormat</code></dfn> of
+            type <span class="idlMemberType">{{ConstrainBoolean}}</span></dt>
             <dd>
-              <p>Some capture modes are more expensive than others when it comes
-              to power consumption. The user agent SHOULD label modes that incur
-              significant power penalty as not power efficient. What format is
-              or is not considered power efficient is up to the user agent, but
-              modes that cause software MJPEG decode are examples of expensive
-              modes.</p>
+              <p>Compressed pixel formats need to be decoded. The user agent
+              SHOULD label compressed pixel formats that incur significant power
+              penalty when decoded as not power efficient. The labeling is up to
+              the user agent, but decoding MJPEG in software is an example of an
+              expensive mode.</p>
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -51,8 +51,10 @@
     <p>
       This document uses the definitions {{MediaDevices}}, {{MediaStreamTrack}},
       {{MediaStreamConstraints}}, {{ConstrainablePattern}},
-      {{MediaTrackConstraintSet}} and {{ConstrainBoolean}} from
-      [[!mediacapture-streams]].
+      {{MediaTrackSupportedConstraints}}, {{MediaTrackCapabilities}},
+      {{MediaTrackConstraintSet}}, {{MediaTrackSettings}},
+      <a data-cite="mediacapture-streams">allowed required constraints for device selection</a>
+      and {{ConstrainBoolean}} from [[!mediacapture-streams]].
       <p>The terms [=permission state=], [=request permission to use=], and
       <a data-cite="permissions">prompt the user to choose</a> are defined in
       [[!permissions]].</p>    </p>
@@ -209,29 +211,105 @@
         </table>
       </div>
     </section>
-    <section id="mediatrackconstraintset-dictionary-extensions">
-      <h3>MediaTrackConstraintSet dictionary extensions</h3>
+    <section id="mediatracksupportedconstraints-dictionary-extensions">
+      <h3>MediaTrackSupportedConstraints dictionary extensions</h3>
       <div>
         <pre class="idl"
->partial dictionary MediaTrackConstraintSet {
-  ConstrainBoolean avoidInefficientCompressedPixelFormat;
+>partial dictionary MediaTrackSupportedConstraints {
+  boolean avoidInefficientCompressedPixelFormat = true;
 };</pre>
         <section>
-          <h2>Dictionary {{MediaTrackConstraintSet}} Members</h2>
-          <dl data-link-for="MediaTrackConstraintSet" data-dfn-for=
-          "MediaTrackConstraintSet" class="dictionary-members">
-            <dt><dfn><code>avoidInefficientCompressedPixelFormat</code></dfn> of
-            type <span class="idlMemberType">{{ConstrainBoolean}}</span></dt>
+          <h2>Dictionary {{MediaTrackSupportedConstraints}} Members</h2>
+          <dl data-link-for="MediaTrackSupportedConstraints" data-dfn-for=
+          "MediaTrackSupportedConstraints" class="dictionary-members">
+            <dt><dfn>avoidInefficientCompressedPixelFormat</dfn> of type
+            {{boolean}}, defaulting to <code>true</code></dt>
+            <dd>See <a href=
+            "#def-constraint-avoidInefficientCompressedPixelFormat">
+            avoidInefficientCompressedPixelFormat</a> for details.</dd>
+          </dl>
+        </section>
+      </div>
+    </section>
+    <section id="mediatrackcapabilities-dictionary-extensions">
+      <h3>MediaTrackCapabilities dictionary extensions</h3>
+      <div>
+        <pre class="idl"
+>partial dictionary MediaTrackCapabilities {
+  sequence&lt;boolean&gt; avoidInefficientCompressedPixelFormat;
+};</pre>
+        <section>
+          <h2>Dictionary {{MediaTrackCapabilities}} Members</h2>
+          <dl data-link-for="MediaTrackCapabilities" data-dfn-for=
+          "MediaTrackCapabilities" class="dictionary-members">
+            <dt><dfn>avoidInefficientCompressedPixelFormat</dfn> of type
+            <code>sequence&lt;{{boolean}}&gt;</code></dt>
             <dd>
+              <p>If the source has no inefficient compressed pixel formats, a
+              single <code>true</code> is reported. If the source only has
+              inefficient compressed pixel formats, a single <code>false</code>
+              is reported. If the script can control the feature, the source
+              reports a list with both <code>true</code> and <code>false</code>
+              as possible values. See <a href=
+              "#def-constraint-avoidInefficientCompressedPixelFormat">
+              avoidInefficientCompressedPixelFormat</a> for additional
+              details.</p>
+            </dd>
+          </dl>
+        </section>
+      </div>
+    </section>
+    <section id="mediatracksettings-dictionary-extensions">
+      <h3>MediaTrackSettings dictionary extensions</h3>
+      <div>
+        <pre class="idl"
+>partial dictionary MediaTrackSettings {
+  boolean avoidInefficientCompressedPixelFormat;
+};</pre>
+        <section>
+          <h2>Dictionary {{MediaTrackSettings}} Members</h2>
+          <dl data-link-for="MediaTrackSettings" data-dfn-for=
+          "MediaTrackSettings" class="dictionary-members">
+            <dt><dfn>avoidInefficientCompressedPixelFormat</dfn> of type
+            {{boolean}}</dt>
+            <dd>See <a href=
+            "#def-constraint-avoidInefficientCompressedPixelFormat">
+            avoidInefficientCompressedPixelFormat</a> for details.</dd>
+      </section>
+      </div>
+    </section>
+      <h2>Constrainable Properties</h2>
+      <h3>Additions to Constrainable Properties</h3>
+      <p>The names of constrainable properties in this document are defined
+      below.</p>
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Property Name</th>
+            <th>Values</th>
+            <th>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><dfn id="def-constraint-avoidInefficientCompressedPixelFormat">
+            avoidInefficientCompressedPixelFormat</dfn></td>
+            <td>{{ConstrainBoolean}}</td>
+            <td>
               <p>Compressed pixel formats need to be decoded. The user agent
               SHOULD label compressed pixel formats that incur significant power
               penalty when decoded as not power efficient. The labeling is up to
               the user agent, but decoding MJPEG in software is an example of an
               expensive mode.</p>
-            </dd>
-          </dl>
-        </section>
-      </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>Additions to allowed required constraints for device selection</h3>
+      <p>The following constrainable properties are
+      <a data-cite="mediacapture-streams">allowed required constraints for device selection</a>:
+      <a>avoidInefficientCompressedPixelFormat</a>.
+      </p>
     </section>
     <section>
       <h2>Algorithms</h2>


### PR DESCRIPTION
Fixes #13.

Add a constraint to allow the application to influence the performance/quality tradeoff. For example we can require the the pixel format is efficient. In practise this could be used to avoid MJPEG decoding load of high resolution USB 2.0 cameras while still allowing high resolution uncompressed NV12 on USB 3.0. The application does not have to care about specific pixel formats, but it can constrain on "efficiency".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/mediacapture-extensions/pull/59.html" title="Last updated on May 20, 2022, 2:07 PM UTC (cea2c4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/59/799b509...henbos:cea2c4a.html" title="Last updated on May 20, 2022, 2:07 PM UTC (cea2c4a)">Diff</a>