### PR TITLE
Remove use of tieSourceToContext since we introduce a dedicated algorithm in mediacapture-main

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,8 +408,7 @@ partial interface MediaStreamTrack {
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/readyState}} to <var>dataHolder</var>.`[[readyState]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/enabled}} to <var>dataHolder</var>.`[[enabled]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/muted}} to <var>dataHolder</var>.`[[muted]]`.</p></li>
-        <li><p>[=MediaStreamTrack/Initialize the underlying source=] of <var>track</var> to <var>dataHolder</var>.`[[source]]` with
-          [=MediaStreamTrack/Initialize the underlying source/tieSourceToContext=] equal to <code>false</code>.</p></li>
+        <li><p>[=MediaStreamTrack/Initialize the underlying source=] of <var>track</var> to <var>dataHolder</var>.`[[source]]`.</p></li>
         <li><p>Set <var>track</var>'s constraints to <var>dataHolder</var>.`[[constraints]]`.</p></li>
       </ol>
     </div>


### PR DESCRIPTION
Counterpart to https://github.com/w3c/mediacapture-main/pull/877


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-extensions/pull/60.html" title="Last updated on Apr 7, 2022, 8:09 AM UTC (e6fb491)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/60/799b509...youennf:e6fb491.html" title="Last updated on Apr 7, 2022, 8:09 AM UTC (e6fb491)">Diff</a>