### PR TITLE
Add changes to configurationchange MediaStreamTrack  event

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@ partial interface MediaStreamTrack {
         <li><p>If <var>changes</var> [=list/is empty=], abort these steps.</p></li>
         <li><p>[=list/Sort=] <var>changes</var> in lexicographical order.</p></li>
         <li>     
-          <p>[=Fire an event=] named {{MediaStreamTrack/configurationchange}}
+          <p>[=Fire an event=] named {{MediaStreamTrack/configurationchange}} using {{ConfigurationChangeEvent}}.
           at <var>track</var> using {{ConfigurationChangeEvent}}, with its 
           {{ConfigurationChangeEvent.changes}} attribute initialized to
           <var>changes</var>.</p>

--- a/index.html
+++ b/index.html
@@ -637,18 +637,22 @@ partial interface MediaStreamTrack {
     </p>
     <p>
       <p>When the [=User Agent=] detects <dfn data-export id="change-track-configuration">a change of configuration</dfn>
-       in a <var>track</var>'s underlying source, the [=User Agent=] MUST run the following steps:</p>
+       in a <var>track</var>'s underlying <var>source</var>, the [=User Agent=] MUST run the following steps:</p>
       <ol>
         <li><p>If <var>track</var>.{{MediaStreamTrack/muted}} is <code>true</code>, wait for <var>track</var>.{{MediaStreamTrack/muted}}
           to become <code>false</code> or <var>track</var>.{{MediaStreamTrack/readyState}} to be "ended".</p></li>
         <li><p>If <var>track</var>.{{MediaStreamTrack/readyState}} is "ended", abort these steps.</p></li>
-        <li><p>If <var>track</var>'s capabilities, constraints and settings are matching <var>source</var> configuration, abort these steps.</li>
         <li>
-          <!-- FIXME: Export capabilities, constraints and settings so that we can use them here. -->
-          <p>Update <var>track</var>'s capabilities, constraints and settings according <var>track</var>'s underlying source.</p>
+          <!-- FIXME: Export capabilities and settings so that we can use them here. -->
+          <p>Update <var>track</var>'s capabilities and settings according <var>track</var>'s underlying source.</p>
         </li>
-        <li><p>Let <var>changes</var> be an empty [=sequence=].</p></li>
-        <li><p>For each change in <var>track</var>'s capabilities and settings, add its name to <var>changes</var>.</p></li>
+        <li><p>Let <var>changes</var> be an empty [=set=].</p></li>
+        <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>source</var>'s settings, if <var>track</var>'s settings does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
+        <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>track</var>'s settings, if <var>source</var>'s settings does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
+        <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>source</var>'s capabilities, if <var>track</var>'s capabilities does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
+        <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>track</var>'s capabilities, if <var>source</var>'s capabilities does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
+        <li><p>If <var>changes</var> [=list/is empty=], abort these steps.</p></li>
+        <li><p>[=list/Sort=] <var>changes</var> in lexicographical order.</p></li>
         <li>     
           <p>[=Fire an event=] named {{MediaStreamTrack/configurationchange}}
           at <var>track</var> using {{ConfigurationChangeEvent}}, with its 
@@ -690,6 +694,9 @@ const [track] = stream.getVideoTracks();
 track.addEventListener("configurationchange", (event) => {
   if (event.changes.includes("backgroundBlur")) {
     // Background blur configuration has changed.
+    if (track.getSettings().backgroundBlur) {
+      // Turn off web app own blurring so that video doesn't get double-blurred.
+    }
   }
 });</pre>
     </div>

--- a/index.html
+++ b/index.html
@@ -654,8 +654,8 @@ partial interface MediaStreamTrack {
         <li><p>If <var>changes</var> [=list/is empty=], abort these steps.</p></li>
         <li><p>[=list/Sort=] <var>changes</var> in lexicographical order.</p></li>
         <li>     
-          <p>[=Fire an event=] named {{MediaStreamTrack/configurationchange}} using {{ConfigurationChangeEvent}}.
-          at <var>track</var> using {{ConfigurationChangeEvent}}, with its 
+          <p>[=Fire an event=] named {{MediaStreamTrack/configurationchange}}
+          using {{ConfigurationChangeEvent}} at <var>track</var>, with its 
           {{ConfigurationChangeEvent.changes}} attribute initialized to
           <var>changes</var>.</p>
         </li>

--- a/index.html
+++ b/index.html
@@ -619,16 +619,22 @@ partial dictionary MediaTrackCapabilities {
   </section>
   <section>
     <h2>Exposing change of MediaStreamTrack configuration</h2>
+    <p>The configuration (capabilities, constraints or settings) of a {{MediaStreamTrack}} may be changed dynamically
+      outside the control of web applications. One example is when a user decides to switch on background blur through
+      the operating system. Web applications might want to know that the configuration
+      of a particular {{MediaStreamTrack}} has changed. For that purpose, a new event is defined below.
+   </p>
+    <h3>MediaStreamTrack Interface Extensions</h3>
     <div>
-      <p>The configuration (capabilities, constraints or settings) of a {{MediaStreamTrack}} may be changed dynamically
-        outside the control of web applications. One example is when a user decides to switch on background blur through
-        the operating system. Web applications might want to know that the configuration
-        of a particular {{MediaStreamTrack}} has changed. For that purpose, a new event is defined below.
-     </p>
-      <pre class="idl">
+    <pre class="idl">
 partial interface MediaStreamTrack {
   attribute EventHandler onconfigurationchange;
 };</pre>
+    <p>The <dfn data-dfn-for="MediaStreamTrack">onconfigurationchange</dfn> attribute
+      is an [=event handler IDL attribute=] for the `onconfigurationchange`
+      [=event handler=], whose [=event handler event type=] is
+      <dfn event for=MediaStreamTrack>configurationchange</dfn>.
+    </p>
     <p>
       <p>When the [=User Agent=] detects <dfn data-export id="change-track-configuration">a change of configuration</dfn>
        in a <var>track</var>'s underlying source, the [=User Agent=] MUST run the following steps:</p>
@@ -636,13 +642,18 @@ partial interface MediaStreamTrack {
         <li><p>If <var>track</var>.{{MediaStreamTrack/muted}} is <code>true</code>, wait for <var>track</var>.{{MediaStreamTrack/muted}}
           to become <code>false</code> or <var>track</var>.{{MediaStreamTrack/readyState}} to be "ended".</p></li>
         <li><p>If <var>track</var>.{{MediaStreamTrack/readyState}} is "ended", abort these steps.</p></li>
-        <li><p>If <var>track</var>'s capabilities, constraints and settings are matching <var>source</var> configuration, abort these steps.
+        <li><p>If <var>track</var>'s capabilities, constraints and settings are matching <var>source</var> configuration, abort these steps.</li>
         <li>
           <!-- FIXME: Export capabilities, constraints and settings so that we can use them here. -->
           <p>Update <var>track</var>'s capabilities, constraints and settings according <var>track</var>'s underlying source.</p>
         </li>
-        <li>
-          <p>[=Fire an event=] named <var>configurationchange</var> on <var>track</var>.</p>
+        <li><p>Let <var>changes</var> be an empty [=sequence=].</p></li>
+        <li><p>For each change in <var>track</var>'s capabilities and settings, add its name to <var>changes</var>.</p></li>
+        <li>     
+          <p>[=Fire an event=] named {{MediaStreamTrack/configurationchange}}
+          at <var>track</var> using {{ConfigurationChangeEvent}}, with its 
+          {{ConfigurationChangeEvent.changes}} attribute initialized to
+          <var>changes</var>.</p>
         </li>
       </ol>
     </p>
@@ -652,6 +663,35 @@ partial interface MediaStreamTrack {
           [=User Agents=] MAY add fuzzing on the timing of events to avoid cross-origin activity correlation.</p>
       </div>
     </p>
+    </div>
+    <h3>ConfigurationChangeEvent Interface</h3>
+    <div>
+      <pre class="idl">
+[Exposed=Window]
+interface ConfigurationChangeEvent : Event {
+  constructor(DOMString type, ConfigurationChangeEventInit changeEventInitDict);
+  readonly attribute FrozenArray&lt;DOMString&gt; changes;
+};
+
+dictionary ConfigurationChangeEventInit : EventInit {
+  required sequence&lt;DOMString&gt; changes;
+};</pre>
+    <p>The <dfn data-dfn-for="ConfigurationChangeEvent">changes</dfn> getter
+      steps are to return the value that the corresponding attribute was
+      initialized to.
+    </p>
+    </div>
+    <h3>Example</h3>
+    <div>
+      <p>This example shows how to monitor external background blur changes.</p>
+      <pre class="example">
+const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+const [track] = stream.getVideoTracks();
+track.addEventListener("configurationchange", (event) => {
+  if (event.changes.includes("backgroundBlur")) {
+    // Background blur configuration has changed.
+  }
+});</pre>
     </div>
   </section>
 </body>


### PR DESCRIPTION
Following https://github.com/w3c/mediacapture-extensions/pull/80#issuecomment-1406646366, here's my naive attempt to expose changes in the configurationchange MediaStreamTrack event.

Live preview: https://pr-preview.s3.amazonaws.com/beaufortfrancois/mediacapture-extensions/pull/83.html#exposing-change-of-mediastreamtrack-configuration

@youennf PTAL


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/mediacapture-extensions/pull/83.html" title="Last updated on Feb 6, 2023, 9:42 AM UTC (5294850)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/83/f885c2a...beaufortfrancois:5294850.html" title="Last updated on Feb 6, 2023, 9:42 AM UTC (5294850)">Diff</a>