### PR TITLE
Update configuration change section

### DIFF
--- a/index.html
+++ b/index.html
@@ -834,17 +834,18 @@ partial interface MediaStreamTrack {
     <div>
     <p>This example shows how to monitor external background blur changes.</p>
     <pre class="example">
-const stream = await navigator.mediaDevices.getUserMedia({video: true});
-const [track] = stream.getVideoTracks();
-let {backgroundBlur} = track.getSettings();
-applyBlurInSoftwareInstead(!backgroundBlur);
+      const stream = await navigator.mediaDevices.getUserMedia({video: true});
+      const [track] = stream.getVideoTracks();
+      let {backgroundBlur} = track.getSettings();
+      applyBlurInSoftwareInstead(!backgroundBlur);
 
-track.addEventListener("configurationchange", () => {
-  if (backgroundBlur != track.getSettings().backgroundBlur) {
-    backgroundBlur = track.getSettings().backgroundBlur;
-    applyBlurInSoftwareInstead(!backgroundBlur);
-  }
-});</pre>
+      track.addEventListener("configurationchange", () => {
+        if (backgroundBlur != track.getSettings().backgroundBlur) {
+          backgroundBlur = track.getSettings().backgroundBlur;
+          applyBlurInSoftwareInstead(!backgroundBlur);
+        }
+      });
+    </pre>
     </div>
   </section>
 </body>

--- a/index.html
+++ b/index.html
@@ -811,13 +811,7 @@ partial interface MediaStreamTrack {
           </p>
           <ol>
             <li><p>If <var>track</var>.{{MediaStreamTrack/readyState}} is "ended", abort these steps.</p></li>
-            <li><p>If <var>track</var>'s capabilities, constraints and settings are matching <var>source</var> configuration, abort these steps.
-            <li><p>Let <var>changes</var> be an empty [=set=].</p></li>
-            <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>source</var>'s settings, if <var>track</var>'s settings does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
-            <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>track</var>'s settings, if <var>source</var>'s settings does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
-            <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>source</var>'s capabilities, if <var>track</var>'s capabilities does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
-            <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>track</var>'s capabilities, if <var>source</var>'s capabilities does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
-            <li><p>If <var>changes</var> [=list/is empty=], abort these steps.</p></li>
+            <li><p>If <var>track</var>'s capabilities and settings are matching <var>source</var> configuration, abort these steps.
             <li>
               <!-- FIXME: Export capabilities and settings so that we can use them here. -->
               <p>Update <var>track</var>'s capabilities and settings according <var>track</var>'s underlying source.</p>
@@ -840,12 +834,15 @@ partial interface MediaStreamTrack {
     <div>
     <p>This example shows how to monitor external background blur changes.</p>
     <pre class="example">
-const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+const stream = await navigator.mediaDevices.getUserMedia({video: true});
 const [track] = stream.getVideoTracks();
-track.addEventListener("configurationchange", (event) => {
-  // Background blur configuration may have changed.
-  if (track.getSettings().backgroundBlur) {
-    // Turn off web app own blurring if needed so that video doesn't get double-blurred.
+let {backgroundBlur} = track.getSettings();
+applyBlurInSoftwareInstead(!backgroundBlur);
+
+track.addEventListener("configurationchange", () => {
+  if (backgroundBlur != track.getSettings().backgroundBlur) {
+    backgroundBlur = track.getSettings().backgroundBlur;
+    applyBlurInSoftwareInstead(!backgroundBlur);
   }
 });</pre>
     </div>

--- a/index.html
+++ b/index.html
@@ -778,15 +778,23 @@ partial dictionary MediaTrackCapabilities {
   <section>
     <h2>Exposing change of MediaStreamTrack configuration</h2>
     <div>
-      <p>The configuration (capabilities, constraints or settings) of a {{MediaStreamTrack}} may be changed dynamically
+      <p>The configuration (capabilities and settings) of a {{MediaStreamTrack}} may be changed dynamically
         outside the control of web applications. One example is when a user decides to switch on background blur through
         the operating system. Web applications might want to know that the configuration
         of a particular {{MediaStreamTrack}} has changed. For that purpose, a new event is defined below.
-     </p>
-      <pre class="idl">
+      </p>
+    </div>
+    <h3>MediaStreamTrack Interface Extensions</h3>
+    <div>
+    <pre class="idl">
 partial interface MediaStreamTrack {
   attribute EventHandler onconfigurationchange;
 };</pre>
+    <p>The <dfn data-dfn-for="MediaStreamTrack">onconfigurationchange</dfn> attribute
+      is an [=event handler IDL attribute=] for the `onconfigurationchange`
+      [=event handler=], whose [=event handler event type=] is
+      <dfn event for=MediaStreamTrack>configurationchange</dfn>.
+    </p>
     <p>
       <p>When the [=User Agent=] detects <dfn data-export id="change-track-configuration">a change of configuration</dfn>
        in a <var>track</var>'s underlying source, the [=User Agent=] MUST run the following steps:</p>
@@ -804,12 +812,18 @@ partial interface MediaStreamTrack {
           <ol>
             <li><p>If <var>track</var>.{{MediaStreamTrack/readyState}} is "ended", abort these steps.</p></li>
             <li><p>If <var>track</var>'s capabilities, constraints and settings are matching <var>source</var> configuration, abort these steps.
+            <li><p>Let <var>changes</var> be an empty [=set=].</p></li>
+            <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>source</var>'s settings, if <var>track</var>'s settings does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
+            <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>track</var>'s settings, if <var>source</var>'s settings does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
+            <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>source</var>'s capabilities, if <var>track</var>'s capabilities does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
+            <li><p>[=map/For each=] <var>key</var>-<var>value</var> pair of <var>track</var>'s capabilities, if <var>source</var>'s capabilities does not have the same pair, [=set/append=] <var>key</var> to <var>changes</var>.</p></li>
+            <li><p>If <var>changes</var> [=list/is empty=], abort these steps.</p></li>
             <li>
-              <!-- FIXME: Export capabilities, constraints and settings so that we can use them here. -->
-              <p>Update <var>track</var>'s capabilities, constraints and settings according <var>track</var>'s underlying source.</p>
+              <!-- FIXME: Export capabilities and settings so that we can use them here. -->
+              <p>Update <var>track</var>'s capabilities and settings according <var>track</var>'s underlying source.</p>
             </li>
             <li>
-              <p>[=Fire an event=] named <var>configurationchange</var> on <var>track</var>.</p>
+              <p>[=Fire an event=] named {{configurationchange}} on <var>track</var>.</p>
             </li>
           </ol>
         </li>
@@ -821,6 +835,19 @@ partial interface MediaStreamTrack {
           [=User Agents=] MAY add fuzzing on the timing of events to avoid cross-origin activity correlation.</p>
       </div>
     </p>
+    </div>
+    <h3>Example</h3>
+    <div>
+    <p>This example shows how to monitor external background blur changes.</p>
+    <pre class="example">
+const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+const [track] = stream.getVideoTracks();
+track.addEventListener("configurationchange", (event) => {
+  // Background blur configuration may have changed.
+  if (track.getSettings().backgroundBlur) {
+    // Turn off web app own blurring if needed so that video doesn't get double-blurred.
+  }
+});</pre>
     </div>
   </section>
 </body>


### PR DESCRIPTION
Based on https://github.com/w3c/mediacapture-extensions/pull/83 and https://github.com/w3c/mediacapture-extensions/pull/80 discussions, this PR improves the status quo of the configuration change section with this changes:
 - Fire the `configurationchange` event only if capabilities and settings differ
 - Add a JavaScript example
 - Define the `configurationchange` event handler event type


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/mediacapture-extensions/pull/89.html" title="Last updated on Mar 16, 2023, 4:29 PM UTC (3e48bd2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/89/932d67b...beaufortfrancois:3e48bd2.html" title="Last updated on Mar 16, 2023, 4:29 PM UTC (3e48bd2)">Diff</a>