### PR TITLE
Delete MediaTrackFrameStats.timestamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,8 +506,6 @@ partial interface MediaStreamTrack {
               <li>
                 <p>Queue a task to resolve <var>p</var> with a newly constructed
                 {{MediaTrackFrameStats}} dictionary where
-                {{MediaTrackFrameStats/timestamp}} is set to
-                <code>Performance.timeOrigin + Performance.now()</code>,
                 {{MediaTrackFrameStats/deliveredFrames}} is set the total number
                 of [= delivered frames =],
                 {{MediaTrackFrameStats/discardedFrames}} is set to the total
@@ -525,7 +523,6 @@ partial interface MediaStreamTrack {
       <div>
         <pre class="idl" data-cite="HR-TIME"
 >dictionary MediaTrackFrameStats {
-  DOMHighResTimeStamp timestamp;
   unsigned long long deliveredFrames;
   unsigned long long discardedFrames;
   unsigned long long totalFrames;
@@ -535,16 +532,6 @@ partial interface MediaStreamTrack {
           <h4>Dictionary {{MediaTrackFrameStats}} Members</h4>
           <dl data-link-for="MediaTrackFrameStats"
           data-dfn-for="MediaTrackFrameStats" class="dictionary-members">
-            <dt>
-              <dfn data-idl="">timestamp</dfn> of type <span class=
-              "idlMemberType">DOMHighResTimeStamp</span>
-            </dt>
-            <dd>
-              <p>
-                The {{timestamp}}, relative to the UNIX epoch (Jan 1, 1970,
-                UTC), for when these stats where collected.
-              </p>
-            </dd>
             <dt>
               <dfn data-idl="">deliveredFrames</dfn> of type <span class=
               "idlMemberType">unsigned long long</span>


### PR DESCRIPTION
Fixes #103


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/mediacapture-extensions/pull/104.html" title="Last updated on Sep 5, 2023, 2:01 PM UTC (780a123)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/104/d917fec...henbos:780a123.html" title="Last updated on Sep 5, 2023, 2:01 PM UTC (780a123)">Diff</a>