### PR TITLE
Change the track stats API to be synchronous

### DIFF
--- a/index.html
+++ b/index.html
@@ -560,7 +560,10 @@ interface MediaStreamTrackVideoStats {
               "https://w3ctag.github.io/design-principles/#js-rtc">run-to-completion</a>
               and no-data-races as defined in [[API-DESIGN-PRINCIPLES]]. That
               is, while a task is running, the frame counters must return the
-              same values every time the getters are called.</p>
+              same values every time the getters are called. The user agent can
+              achieve this for example by posting tasks to update these values
+              or to cache the values upon getting and clear the cache in the
+              next task execution cycle.</p>
             </div>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -567,8 +567,7 @@ interface MediaStreamTrackVideoStats {
             <dd>
               <p>
                 Upon getting, run the [= expose frame counters steps =] and
-                return this track stats'
-                {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}}.
+                return {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}}.
               </p>
             </dd>
             <dt>
@@ -578,8 +577,7 @@ interface MediaStreamTrackVideoStats {
             <dd>
               <p>
                 Upon getting, run the [= expose frame counters steps =] and
-                return this track stats'
-                {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}}.
+                return {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}}.
               </p>
             </dd>
             <dt>
@@ -589,8 +587,7 @@ interface MediaStreamTrackVideoStats {
             <dd>
               <p>
                 Upon getting, run the [= expose frame counters steps =] and
-                return this track stats'
-                {{MediaStreamTrackVideoStats/[[TotalFrames]]}}.
+                return {{MediaStreamTrackVideoStats/[[TotalFrames]]}}.
               </p>
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -540,9 +540,8 @@ interface MediaStreamTrackVideoStats {
             <li>
               <p>If this is the first time the [= expose frame counters steps =]
               are called in this task execution cycle, set the internal slots of
-              <var>track</var>.{{MediaStreamTrack/[[VideoStats]]}} as follows:
-              {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}} is set to
-              [= delivered frames =],
+              as follows: {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}} is
+              set to [= delivered frames =],
               {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}} is set to
               [= discarded frames =] and
               {{MediaStreamTrackVideoStats/[[TotalFrames]]}} is set to

--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@ partial interface MediaStreamTrack {
       <p>The underlying source is supposed to be kept alive between the transfer and transfer-receiving steps, or as long as the data holder is alive.
       In a sense, between these steps, the data holder is attached to the underlying source as if it was a track.</p>
     </div>
-    <h3>MediaStreamTrack frame stats</h3>
+    <h3>MediaStreamTrack Statistics</h3>
     <div>
       <p>
         On camera and screenshare tracks, frame counters allow the application
@@ -434,13 +434,20 @@ partial interface MediaStreamTrack {
     <div>
       <pre class="idl"
 >partial interface MediaStreamTrack {
-  Promise&lt;MediaTrackFrameStats&gt; getFrameStats();
+  [SameObject] readonly attribute MediaStreamTrackVideoStats videoStats;
 };
 </pre>
     </div>
     <div>
-      <p>If a {{MediaStreamTrack}} is sourced from <code>getUserMedia()</code>
-      or <code>getDisplayMedia()</code>, the user agent is required to count
+      <p>Let the {{MediaStreamTrack}} have a
+      <dfn class=export data-dfn-for="MediaStreamTrack">[[\VideoStats]]</dfn>
+      internal slot. If the {{MediaStreamTrack}} is sourced from
+      <code>getUserMedia()</code> or <code>getDisplayMedia()</code> and is of
+      {{MediaStreamTrack/kind}} <code>"video"</code>, initialize
+      {{MediaStreamTrack/[[VideoStats]]}} to a new instance of
+      {{MediaStreamTrackVideoStats}} set up to expose video stats for this
+      {{MediaStreamTrack}}. Otherwise, initialized it to <code>null</code>.</p>
+      <p>For tracks exposing video stats, the user agent is required to count
       each frame from its source as follows:</p>
       <ul>
         <li>
@@ -474,91 +481,87 @@ partial interface MediaStreamTrack {
       </ul>
     </div>
     <section>
-      <h4>Methods</h4>
+      <h4>Attributes</h4>
       <dl data-link-for="MediaStreamTrack" data-dfn-for="MediaStreamTrack"
-      class="methods">
+      class="attributes">
         <dt>
-          <dfn>getFrameStats</dfn>
+          <dfn data-idl="">videoStats</dfn> of type
+          {{MediaStreamTrackVideoStats}}, readonly
         </dt>
         <dd>
           <p>
-            When this method is called, the user agenst MUST run the following
+            When this getter is called, the user agenst MUST run the following
             steps:
           </p>
           <ol>
             <li>
               <p>
                 Let <var>track</var> be the {{MediaStreamTrack}} that this
-                method was called on.
+                getter is called on.
               </p>
             </li>
             <li>
-              <p>If <var>track</var> is not sourced from
-              <code>getUserMedia()</code> or <code>getDisplayMedia()</code>,
-              reject this method with {{NotSupportedError}} and abort these
+              <p>If <var>track</var>.{{MediaStreamTrack/[[VideoStats]]}} is
+              <code>null</code>, throw {{NotSupportedError}} and abort these
               steps.</p>
             </li>
             <li>
-              <p>Let <var>p</var> be a new promise. Begin running the following
-              steps in parallel and return <var>p</var>:</p>
+              <p>Return
+              <var>track</var>.{{MediaStreamTrack/[[VideoStats]]}}.</p>
             </li>
-            <ol>
-              <li>
-                <p>Queue a task to resolve <var>p</var> with a newly constructed
-                {{MediaTrackFrameStats}} dictionary where
-                {{MediaTrackFrameStats/deliveredFrames}} is set the total number
-                of [= delivered frames =],
-                {{MediaTrackFrameStats/discardedFrames}} is set to the total
-                number of [= discarded frames =] and
-                {{MediaTrackFrameStats/totalFrames}} is set to the
-                [= total frames =] count.</p>
-              </li>
-            </ol>
           </ol>
         </dd>
       </dl>
     </section>
     <section>
-      <h4>The MediaTrackFrameStats dictionary</h4>
+      <h4>The MediaStreamTrackVideoStats interface</h4>
       <div>
-        <pre class="idl" data-cite="HR-TIME"
->dictionary MediaTrackFrameStats {
-  unsigned long long deliveredFrames;
-  unsigned long long discardedFrames;
-  unsigned long long totalFrames;
+        <pre class="idl">[Exposed=Window]
+interface MediaStreamTrackVideoStats {
+  readonly attribute unsigned long long deliveredFrames;
+  readonly attribute unsigned long long discardedFrames;
+  readonly attribute unsigned long long totalFrames;
 };
 </pre>
         <section>
-          <h4>Dictionary {{MediaTrackFrameStats}} Members</h4>
-          <dl data-link-for="MediaTrackFrameStats"
-          data-dfn-for="MediaTrackFrameStats" class="dictionary-members">
+          <h4>Attributes</h4>
+          <dl data-link-for="MediaStreamTrackVideoStats"
+          data-dfn-for="MediaStreamTrackVideoStats" class="attributes">
             <dt>
               <dfn data-idl="">deliveredFrames</dfn> of type <span class=
-              "idlMemberType">unsigned long long</span>
+              "idlMemberType">unsigned long long, readonly</span>
             </dt>
             <dd>
               <p>
-                The total number of [= delivered frames =].
+                Upon getting, return the total number of [= delivered frames =].
               </p>
             </dd>
             <dt>
               <dfn data-idl="">discardedFrames</dfn> of type <span class=
-              "idlMemberType">unsigned long long</span>
+              "idlMemberType">unsigned long long, readonly</span>
             </dt>
             <dd>
               <p>
-                The total number of [= discarded frames =].
+                Upon getting, return the total number of [= discarded frames =].
               </p>
             </dd>
             <dt>
               <dfn data-idl="">totalFrames</dfn> of type <span class=
-              "idlMemberType">unsigned long long</span>
+              "idlMemberType">unsigned long long, readonly</span>
             </dt>
             <dd>
               <p>
-                The [= total frames =] count.
+                Upon getting, return the [= total frames =] count.
               </p>
             </dd>
+            <div class="note">
+              <p>The general principles for Javascript APIs apply, including the
+              principle of <a href=
+              "https://w3ctag.github.io/design-principles/#js-rtc">run-to-completion</a>
+              and no-data-races as defined in [[API-DESIGN-PRINCIPLES]]. That
+              is, while a task is running, the frame counters must return the
+              same values every time the getters are called.</p>
+            </div>
           </dl>
         </section>
       </div>

--- a/index.html
+++ b/index.html
@@ -539,9 +539,10 @@ interface MediaStreamTrackVideoStats {
           <ul>
             <li>
               <p>If this is the first time the [= expose frame counters steps =]
-              are called in this task execution cycle, set the internal slots of
-              as follows: {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}} is
-              set to [= delivered frames =],
+              are called for this {{MediaStreamTrackVideoStats}} in this task
+              execution cycle, set the internal slots of as follows:
+              {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}} is set to
+              [= delivered frames =],
               {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}} is set to
               [= discarded frames =] and
               {{MediaStreamTrackVideoStats/[[TotalFrames]]}} is set to

--- a/index.html
+++ b/index.html
@@ -506,6 +506,25 @@ partial interface MediaStreamTrack {
               steps.</p>
             </li>
             <li>
+              <p>
+                If this is the first time this getter is called in this task
+                exection cycle, set the internal slots of
+                <var>track</var>.{{MediaStreamTrack/[[VideoStats]]}} as follows:
+                {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}} is set to
+                [= delivered frames =],
+                {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}} is set to
+                [= discarded frames =] and
+                {{MediaStreamTrackVideoStats/[[TotalFrames]]}} is set to
+                [= total frames =].
+              </p>
+              <div class="note">
+                <p>Only updating these counters once per task execution cycles
+                preserves the <a href=
+                "https://w3ctag.github.io/design-principles/#js-rtc">run-to-completion</a>
+                semantics defined in [[API-DESIGN-PRINCIPLES]].</p>
+              </div>
+            </li>
+            <li>
               <p>Return
               <var>track</var>.{{MediaStreamTrack/[[VideoStats]]}}.</p>
             </li>
@@ -522,7 +541,16 @@ interface MediaStreamTrackVideoStats {
   readonly attribute unsigned long long discardedFrames;
   readonly attribute unsigned long long totalFrames;
 };
-</pre>
+        </pre>
+        <div>
+          <p>Let the {{MediaStreamTrackVideoStats}} have internal slots
+          <dfn class=export data-dfn-for="MediaStreamTrackVideoStats">[[\DeliveredFrames]]</dfn>,
+          <dfn class=export data-dfn-for="MediaStreamTrackVideoStats">[[\DiscardedFrames]]</dfn>
+          and
+          <dfn class=export data-dfn-for="MediaStreamTrackVideoStats">[[\TotalFrames]]</dfn>,
+          initialized to 0.
+          </p>
+        </div>
         <section>
           <h4>Attributes</h4>
           <dl data-link-for="MediaStreamTrackVideoStats"
@@ -533,7 +561,8 @@ interface MediaStreamTrackVideoStats {
             </dt>
             <dd>
               <p>
-                Upon getting, return the total number of [= delivered frames =].
+                Upon getting, return this track stats'
+                {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}}.
               </p>
             </dd>
             <dt>
@@ -542,7 +571,8 @@ interface MediaStreamTrackVideoStats {
             </dt>
             <dd>
               <p>
-                Upon getting, return the total number of [= discarded frames =].
+                Upon getting, return this track stats'
+                {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}}.
               </p>
             </dd>
             <dt>
@@ -551,20 +581,10 @@ interface MediaStreamTrackVideoStats {
             </dt>
             <dd>
               <p>
-                Upon getting, return the [= total frames =] count.
+                Upon getting, return this track stats'
+                {{MediaStreamTrackVideoStats/[[TotalFrames]]}}.
               </p>
             </dd>
-            <div class="note">
-              <p>The general principles for Javascript APIs apply, including the
-              principle of <a href=
-              "https://w3ctag.github.io/design-principles/#js-rtc">run-to-completion</a>
-              and no-data-races as defined in [[API-DESIGN-PRINCIPLES]]. That
-              is, while a task is running, the frame counters must return the
-              same values every time the getters are called. The user agent can
-              achieve this for example by posting tasks to update these values
-              or to cache the values upon getting and clear the cache in the
-              next task execution cycle.</p>
-            </div>
           </dl>
         </section>
       </div>

--- a/index.html
+++ b/index.html
@@ -508,7 +508,7 @@ partial interface MediaStreamTrack {
             <li>
               <p>
                 If this is the first time this getter is called in this task
-                exection cycle, set the internal slots of
+                execution cycle, set the internal slots of
                 <var>track</var>.{{MediaStreamTrack/[[VideoStats]]}} as follows:
                 {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}} is set to
                 [= delivered frames =],

--- a/index.html
+++ b/index.html
@@ -447,38 +447,6 @@ partial interface MediaStreamTrack {
       {{MediaStreamTrack/[[VideoStats]]}} to a new instance of
       {{MediaStreamTrackVideoStats}} set up to expose video stats for this
       {{MediaStreamTrack}}. Otherwise, initialized it to <code>null</code>.</p>
-      <p>For tracks exposing video stats, the user agent is required to count
-      each frame from its source as follows:</p>
-      <ul>
-        <li>
-          <p>A frame is considered
-          <dfn data-lt="delivered frames">delivered</dfn> if it either was
-          delivered to a sink or would have been delivered to a sink, if one was
-          connected. This is a subset of [= total frames =] and it is
-          incremented at the same time as [= total frames =].</p>
-        </li>
-        <li>
-          <p>A frame is considered
-          <dfn data-lt="discarded frames">discarded</dfn> if it was discarded in
-          order to achieve the target {{MediaTrackSettings/frameRate}}.
-          This is a subset of [= total frames =] and it is incremented at the
-          same time as [= total frames =].</p>
-        </li>
-        <li>
-          <p>The <dfn data-lt="total frames">total</dfn> number of frames that
-          have been processed by this source, meaning it is known whether the
-          frame was considered delivered, discarded or dropped for any other
-          reason. The number of dropped frames for various unknown reasons can
-          be calculated by subtracting [= delivered frames =] and
-          [= discarded frames =] from [= total frames =].</p>
-          <div class="note">
-            <p>If the track is unmuted and enabled and the source is backed by
-            a camera, total frames is incremented by frames produced by the
-            camera. If no frames are flowing, such as if the track is muted or
-            disabled, then total frames does not increment.</p>
-          </div>
-        </li>
-      </ul>
     </div>
     <section>
       <h4>Attributes</h4>
@@ -506,25 +474,6 @@ partial interface MediaStreamTrack {
               steps.</p>
             </li>
             <li>
-              <p>
-                If this is the first time this getter is called in this task
-                execution cycle, set the internal slots of
-                <var>track</var>.{{MediaStreamTrack/[[VideoStats]]}} as follows:
-                {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}} is set to
-                [= delivered frames =],
-                {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}} is set to
-                [= discarded frames =] and
-                {{MediaStreamTrackVideoStats/[[TotalFrames]]}} is set to
-                [= total frames =].
-              </p>
-              <div class="note">
-                <p>Only updating these counters once per task execution cycles
-                preserves the <a href=
-                "https://w3ctag.github.io/design-principles/#js-rtc">run-to-completion</a>
-                semantics defined in [[API-DESIGN-PRINCIPLES]].</p>
-              </div>
-            </li>
-            <li>
               <p>Return
               <var>track</var>.{{MediaStreamTrack/[[VideoStats]]}}.</p>
             </li>
@@ -543,6 +492,41 @@ interface MediaStreamTrackVideoStats {
 };
         </pre>
         <div>
+          <p>The {{MediaStreamTrackVideoStats}} expose frame counters for the
+          {{MediaStreamTrack}} that created it. For this track, the user agent
+          is required to count each frame from its source as follows:</p>
+          <ul>
+            <li>
+              <p>A frame is considered
+              <dfn data-lt="delivered frames">delivered</dfn> if it either was
+              delivered to a sink or would have been delivered to a sink, if one
+              was connected. This is a subset of [= total frames =] and it is
+              incremented at the same time as [= total frames =].</p>
+            </li>
+            <li>
+              <p>A frame is considered
+              <dfn data-lt="discarded frames">discarded</dfn> if it was
+              discarded in order to achieve the target
+              {{MediaTrackSettings/frameRate}}. This is a subset of
+              [= total frames =] and it is incremented at the same time as
+              [= total frames =].</p>
+            </li>
+            <li>
+              <p>The <dfn data-lt="total frames">total</dfn> number of frames
+              that have been processed by this source, meaning it is known
+              whether the frame was considered delivered, discarded or dropped
+              for any other reason. The number of dropped frames for various
+              unknown reasons can be calculated by subtracting
+              [= delivered frames =] and [= discarded frames =] from
+              [= total frames =].</p>
+              <div class="note">
+                <p>If the track is unmuted and enabled and the source is backed
+                by a camera, total frames is incremented by frames produced by
+                the camera. If no frames are flowing, such as if the track is
+                muted or disabled, then total frames does not increment.</p>
+              </div>
+            </li>
+          </ul>
           <p>Let the {{MediaStreamTrackVideoStats}} have internal slots
           <dfn class=export data-dfn-for="MediaStreamTrackVideoStats">[[\DeliveredFrames]]</dfn>,
           <dfn class=export data-dfn-for="MediaStreamTrackVideoStats">[[\DiscardedFrames]]</dfn>
@@ -550,6 +534,28 @@ interface MediaStreamTrackVideoStats {
           <dfn class=export data-dfn-for="MediaStreamTrackVideoStats">[[\TotalFrames]]</dfn>,
           initialized to 0.
           </p>
+          <p>The <dfn data-lt="expose frame counters steps">expose frame
+          counters steps</dfn> are the following:</p>
+          <ul>
+            <li>
+              <p>If this is the first time the [= expose frame counters steps =]
+              are called in this task execution cycle, set the internal slots of
+              <var>track</var>.{{MediaStreamTrack/[[VideoStats]]}} as follows:
+              {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}} is set to
+              [= delivered frames =],
+              {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}} is set to
+              [= discarded frames =] and
+              {{MediaStreamTrackVideoStats/[[TotalFrames]]}} is set to
+              [= total frames =].
+              </p>
+              <div class="note">
+                <p>Only updating these counters once per task execution cycles
+                preserves the <a href=
+                "https://w3ctag.github.io/design-principles/#js-rtc">run-to-completion</a>
+                semantics defined in [[API-DESIGN-PRINCIPLES]].</p>
+              </div>
+            </li>
+          </ul>
         </div>
         <section>
           <h4>Attributes</h4>
@@ -561,7 +567,8 @@ interface MediaStreamTrackVideoStats {
             </dt>
             <dd>
               <p>
-                Upon getting, return this track stats'
+                Upon getting, run the [= expose frame counters steps =] and
+                return this track stats'
                 {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}}.
               </p>
             </dd>
@@ -571,7 +578,8 @@ interface MediaStreamTrackVideoStats {
             </dt>
             <dd>
               <p>
-                Upon getting, return this track stats'
+                Upon getting, run the [= expose frame counters steps =] and
+                return this track stats'
                 {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}}.
               </p>
             </dd>
@@ -581,7 +589,8 @@ interface MediaStreamTrackVideoStats {
             </dt>
             <dd>
               <p>
-                Upon getting, return this track stats'
+                Upon getting, run the [= expose frame counters steps =] and
+                return this track stats'
                 {{MediaStreamTrackVideoStats/[[TotalFrames]]}}.
               </p>
             </dd>


### PR DESCRIPTION
Fixes #105


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/mediacapture-extensions/pull/106.html" title="Last updated on Sep 12, 2023, 4:24 PM UTC (0ded789)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/106/ade2858...henbos:0ded789.html" title="Last updated on Sep 12, 2023, 4:24 PM UTC (0ded789)">Diff</a>