### PR TITLE
Add current latency to audio track.stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,6 +507,7 @@ interface MediaStreamTrackAudioStats {
   readonly attribute unsigned long long deliveredFrames;
   readonly attribute DOMHighResTimeStamp deliveredFramesDuration;
   readonly attribute DOMHighResTimeStamp deliveredFramesLatency;
+  readonly attribute DOMHighResTimeStamp? latency;
   readonly attribute unsigned long long totalFrames;
   readonly attribute DOMHighResTimeStamp totalFramesDuration;
   [Default] object toJSON();
@@ -546,6 +547,12 @@ interface MediaStreamTrackAudioStats {
               frames =].</p>
             </div>
             <li>
+              <p>The <dfn data-lt="current audio latency">current audio
+              latency</dfn> is the input latency of the last audio frame that
+              was delivered. If no audio frames have been delivered yet, this
+              value is <code>null</code>.</p>
+            </li>
+            <li>
               <p>An audio frame that is discarded because it cannot be delivered
               on time, or it cannot be delivered for any other reason, is
               considered <dfn data-lt="dropped audio frames">dropped</dfn>.</p>
@@ -575,7 +582,8 @@ interface MediaStreamTrackAudioStats {
           <p>Let the {{MediaStreamTrackAudioStats}} have internal slots
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFrames]]</dfn>,
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesDuration]]</dfn>,
-          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesLatency]]</dfn>
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesLatency]]</dfn>,
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\Latency]]</dfn>,
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFrames]]</dfn>,
           and
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFramesDuration]]</dfn>,
@@ -593,6 +601,8 @@ interface MediaStreamTrackAudioStats {
               to [= delivered audio frames duration =],
               {{MediaStreamTrackAudioStats/[[DeliveredFramesLatency]]}} is set to
               [= delivered audio frames latency =],
+              {{MediaStreamTrackAudioStats/[[Latency]]}} is set to
+              [= current audio latency =],
               {{MediaStreamTrackAudioStats/[[DroppedFrames]]}} is set to
               [= dropped audio frames =] and
               {{MediaStreamTrackAudioStats/[[DroppedFramesDuration]]}} is set to
@@ -641,6 +651,17 @@ interface MediaStreamTrackAudioStats {
                 Upon getting, run the [= expose audio frame counters steps =]
                 and return
                 {{MediaStreamTrackAudioStats/[[DeliveredFramesLatency]]}}.
+              </p>
+            </dd>
+            <dt>
+              <dfn data-idl="">latency</dfn> of type <span
+              class="idlMemberType">DOMHighResTimeStamp, readonly,
+              nullable</span>
+            </dt>
+            <dd>
+              <p>
+                Upon getting, run the [= expose audio frame counters steps =]
+                and return {{MediaStreamTrackAudioStats/[[Latency]]}}.
               </p>
             </dd>
             <dt>

--- a/index.html
+++ b/index.html
@@ -506,9 +506,9 @@ partial interface MediaStreamTrack {
 interface MediaStreamTrackAudioStats {
   readonly attribute unsigned long long deliveredFrames;
   readonly attribute DOMHighResTimeStamp deliveredFramesDuration;
-  readonly attribute DOMHighResTimeStamp deliveredFramesDelay;
-  readonly attribute unsigned long long droppedFrames;
-  readonly attribute DOMHighResTimeStamp droppedFramesDuration;
+  readonly attribute DOMHighResTimeStamp deliveredFramesLatency;
+  readonly attribute unsigned long long totalFrames;
+  readonly attribute DOMHighResTimeStamp totalFramesDuration;
   [Default] object toJSON();
 };
         </pre>
@@ -525,29 +525,36 @@ interface MediaStreamTrackAudioStats {
             <li>
               <p>The <dfn data-lt="delivered audio frames duration">delivered
               audio frames duration</dfn> is the total duration of all
-              [= delivered audio frames =], in milliseconds.</p>
+              [= delivered audio frames =]. This measurement is incremented at
+              the same time as [= delivered audio frames =] and is measured in
+              milliseconds.</p>
             </li>
             <li>
-              <p>The <dfn data-lt="delivered audio frames delay">delivered audio
-              frames delay</dfn> is the sum of [= delivered audio frames =]'s
-              capture delays. The capture delay is the estimated time between
-              the capture device emitting the frame and the frame being
-              considered delivered, in milliseconds.</p>
+              <p>The <dfn data-lt="delivered audio frames latency">delivered
+              audio frames latency</dfn> is the sum of [= delivered audio
+              frames =]'s input latency. The input latency is the estimated
+              latency of the capture device plus the time time it takes the user
+              agent to deliver that frame. This measurement is incremented at
+              the same time as [= delivered audio frames =] and is measured in
+              milliseconds. Note that once a frame has been delivered to a sink,
+              that sink may internally have its own latency (such as playout
+              delay) which is not included in this measurement.</p>
             </li>
             <div class="note">
-              <p>The average capture delay per audio frame can be calculated as
-              [= delivered audio frames delay =] / [= delivered audio
+              <p>The average latency per audio frame can be calculated as
+              [= delivered audio frames latency =] / [= delivered audio
               frames =].</p>
             </div>
             <li>
               <p>An audio frame that is discarded because it cannot be delivered
-              on time is considered
-              <dfn data-lt="dropped audio frames">dropped</dfn>.</p>
+              on time, or it cannot be delivered for any other reason, is
+              considered <dfn data-lt="dropped audio frames">dropped</dfn>.</p>
             </li>
             <li>
               <p>The <dfn data-lt="dropped audio frames duration">dropped audio
               frames duration</dfn> is the total duration of all [= dropped
-              audio frames =], in milliseconds.</p>
+              audio frames =]. This measurement is incremented at the same time
+              as [= dropped audio frames =] and is measured in milliseconds.</p>
             </li>
             <div class="note">
               <p>Because audio capture devices produce audio in real-time,
@@ -568,7 +575,7 @@ interface MediaStreamTrackAudioStats {
           <p>Let the {{MediaStreamTrackAudioStats}} have internal slots
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFrames]]</dfn>,
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesDuration]]</dfn>,
-          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesDelay]]</dfn>
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesLatency]]</dfn>
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFrames]]</dfn>,
           and
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFramesDuration]]</dfn>,
@@ -584,8 +591,8 @@ interface MediaStreamTrackAudioStats {
               [= delivered audio frames =],
               {{MediaStreamTrackAudioStats/[[DeliveredFramesDuration]]}} is set
               to [= delivered audio frames duration =],
-              {{MediaStreamTrackAudioStats/[[DeliveredFramesDelay]]}} is set to
-              [= delivered audio frames delay =],
+              {{MediaStreamTrackAudioStats/[[DeliveredFramesLatency]]}} is set to
+              [= delivered audio frames latency =],
               {{MediaStreamTrackAudioStats/[[DroppedFrames]]}} is set to
               [= dropped audio frames =] and
               {{MediaStreamTrackAudioStats/[[DroppedFramesDuration]]}} is set to
@@ -626,34 +633,37 @@ interface MediaStreamTrackAudioStats {
               </p>
             </dd>
             <dt>
-              <dfn data-idl="">deliveredFramesDelay</dfn> of type <span
+              <dfn data-idl="">deliveredFramesLatency</dfn> of type <span
               class="idlMemberType">DOMHighResTimeStamp, readonly</span>
             </dt>
             <dd>
               <p>
                 Upon getting, run the [= expose audio frame counters steps =]
                 and return
-                {{MediaStreamTrackAudioStats/[[DeliveredFramesDelay]]}}.
+                {{MediaStreamTrackAudioStats/[[DeliveredFramesLatency]]}}.
               </p>
             </dd>
             <dt>
-              <dfn data-idl="">droppedFrames</dfn> of type <span class=
+              <dfn data-idl="">totalFrames</dfn> of type <span class=
               "idlMemberType">unsigned long long, readonly</span>
             </dt>
             <dd>
               <p>
                 Upon getting, run the [= expose audio frame counters steps =]
-                and return {{MediaStreamTrackAudioStats/[[DroppedFrames]]}}.
+                and return the sum of
+                {{MediaStreamTrackAudioStats/[[DeliveredFrames]]}} and
+                {{MediaStreamTrackAudioStats/[[DroppedFrames]]}}.
               </p>
             </dd>
             <dt>
-              <dfn data-idl="">droppedFramesDuration</dfn> of type <span class=
+              <dfn data-idl="">totalFramesDuration</dfn> of type <span class=
               "idlMemberType">DOMHighResTimeStamp, readonly</span>
             </dt>
             <dd>
               <p>
                 Upon getting, run the [= expose audio frame counters steps =]
-                and return
+                and return the sum of
+                {{MediaStreamTrackAudioStats/[[DeliveredFramesDuration]]}} and
                 {{MediaStreamTrackAudioStats/[[DroppedFramesDuration]]}}.
               </p>
             </dd>

--- a/index.html
+++ b/index.html
@@ -434,27 +434,45 @@ partial interface MediaStreamTrack {
     <div>
       <pre class="idl"
 >partial interface MediaStreamTrack {
-  [SameObject] readonly attribute MediaStreamTrackVideoStats stats;
+  [SameObject] readonly attribute
+      (MediaStreamTrackAudioStats or MediaStreamTrackVideoStats) stats;
 };
 </pre>
     </div>
     <div>
       <p>Let the {{MediaStreamTrack}} have a
-      <dfn class=export data-dfn-for="MediaStreamTrack">[[\VideoStats]]</dfn>
-      internal slot. If the {{MediaStreamTrack}} is sourced from
-      <code>getUserMedia()</code> or <code>getDisplayMedia()</code> and is of
-      {{MediaStreamTrack/kind}} <code>"video"</code>, initialize
-      {{MediaStreamTrack/[[VideoStats]]}} to a new instance of
-      {{MediaStreamTrackVideoStats}} set up to expose video stats for this
-      {{MediaStreamTrack}}. Otherwise, initialized it to <code>null</code>.</p>
+      <dfn class=export data-dfn-for="MediaStreamTrack">[[\Stats]]</dfn>
+      internal slot initialized it to <code>null</code>, unless otherwise
+      specified below.</p>
+      <p>If the track's is of {{MediaStreamTrack/kind}} <code>"audio"</code>,
+      run the following steps:</p>
+      <ol>
+        <li>
+          <p>If the {{MediaStreamTrack}} is sourced from
+          <code>getUserMedia()</code>, initialize {{MediaStreamTrack/[[Stats]]}}
+          to a new instance of {{MediaStreamTrackAudioStats}} set up to expose
+          audio stats for this {{MediaStreamTrack}}.</p>
+        </li>
+      </ol>
+      <p>If the track's is of {{MediaStreamTrack/kind}} <code>"video"</code>,
+      run the following steps:</p>
+      <ol>
+        <li>
+          <p>If the {{MediaStreamTrack}} is sourced from
+          <code>getUserMedia()</code> or <code>getDisplayMedia()</code>,
+          initialize {{MediaStreamTrack/[[Stats]]}} to a new instance of
+          {{MediaStreamTrackVideoStats}} set up to expose video stats for this
+          {{MediaStreamTrack}}.</p>
+        </li>
+      </ol>
     </div>
     <section>
       <h4>Attributes</h4>
       <dl data-link-for="MediaStreamTrack" data-dfn-for="MediaStreamTrack"
       class="attributes">
         <dt>
-          <dfn data-idl="">stats</dfn> of type {{MediaStreamTrackVideoStats}},
-          readonly
+          <dfn data-idl="">stats</dfn> of type ({{MediaStreamTrackAudioStats}}
+          or {{MediaStreamTrackVideoStats}}), readonly
         </dt>
         <dd>
           <p>
@@ -469,17 +487,193 @@ partial interface MediaStreamTrack {
               </p>
             </li>
             <li>
-              <p>If <var>track</var>.{{MediaStreamTrack/[[VideoStats]]}} is
+              <p>If <var>track</var>.{{MediaStreamTrack/[[Stats]]}} is
               <code>null</code>, throw {{NotSupportedError}} and abort these
               steps.</p>
             </li>
             <li>
-              <p>Return
-              <var>track</var>.{{MediaStreamTrack/[[VideoStats]]}}.</p>
+              <p>Return <var>track</var>.{{MediaStreamTrack/[[Stats]]}}.</p>
             </li>
           </ol>
         </dd>
       </dl>
+    </section>
+  </section>
+    <section>
+      <h4>The MediaStreamTrackAudioStats interface</h4>
+      <div>
+        <pre class="idl" data-cite="HR-TIME">[Exposed=Window]
+interface MediaStreamTrackAudioStats {
+  readonly attribute unsigned long long deliveredFrames;
+  readonly attribute DOMHighResTimeStamp deliveredFramesDuration;
+  readonly attribute DOMHighResTimeStamp deliveredFramesDelay;
+  readonly attribute unsigned long long droppedFrames;
+  readonly attribute DOMHighResTimeStamp droppedFramesDuration;
+  [Default] object toJSON();
+};
+        </pre>
+        <div>
+          <p>The {{MediaStreamTrackAudioStats}} expose frame counters for the
+          {{MediaStreamTrack}} that created it. For this track, the user agent
+          is required to count each audio frame from its source as follows:</p>
+          <ul>
+            <li>
+              <p>A frame is considered a <dfn data-lt="delivered audio frames">
+              delivered audio frame</dfn> if it either was delivered to a sink
+              or would have been delivered to a sink, if one was connected.</p>
+            </li>
+            <li>
+              <p>The <dfn data-lt="delivered audio frames duration">delivered
+              audio frames duration</dfn> is the total duration of all
+              [= delivered audio frames =], in milliseconds.</p>
+            </li>
+            <li>
+              <p>The <dfn data-lt="delivered audio frames delay">delivered audio
+              frames delay</dfn> is the sum of [= delivered audio frames =]'s
+              capture delays. The capture delay is the estimated time between
+              the capture device emitting the frame and the frame being
+              considered delivered, in milliseconds.</p>
+            </li>
+            <div class="note">
+              <p>The average capture delay per audio frame can be calculated as
+              [= delivered audio frames delay =] / [= delivered audio
+              frames =].</p>
+            </div>
+            <li>
+              <p>An audio frame that is discarded because it cannot be delivered
+              on time is considered
+              <dfn data-lt="dropped audio frames">dropped</dfn>.</p>
+            </li>
+            <li>
+              <p>The <dfn data-lt="dropped audio frames duration">dropped audio
+              frames duration</dfn> is the total duration of all [= dropped
+              audio frames =], in milliseconds.</p>
+            </li>
+            <div class="note">
+              <p>Because audio capture devices produce audio in real-time,
+              audio frames may be dropped if not processed in a timely
+              manner.</p>
+              <p>The percentage of audio that was dropped can be calculated as
+              [= dropped audio frames duration =] / ([= delivered audio frames
+              duration =] + [= dropped audio frames duration =]).</p>
+            </div>
+            <div class="note">
+              <p>If the track is unmuted and enabled, the counters increase as
+              audio is produced by the capture device. If no audio is flowing,
+              such as if the track is muted or disabled, then the counters do
+              not increase.</p>
+            </div>
+            </li>
+          </ul>
+          <p>Let the {{MediaStreamTrackAudioStats}} have internal slots
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFrames]]</dfn>,
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesDuration]]</dfn>,
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesDelay]]</dfn>
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFrames]]</dfn>,
+          and
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFramesDuration]]</dfn>,
+          initialized to 0.</p>
+          <p>The <dfn data-lt="expose audio frame counters steps">expose audio
+          frame counters steps</dfn> are the following:</p>
+          <ul>
+            <li>
+              <p>If this is the first time the [= expose audio frame counters
+              steps =] are called for this {{MediaStreamTrackAudioStats}} in
+              this task execution cycle, set the internal slots of as follows:
+              {{MediaStreamTrackAudioStats/[[DeliveredFrames]]}} is set to
+              [= delivered audio frames =],
+              {{MediaStreamTrackAudioStats/[[DeliveredFramesDuration]]}} is set
+              to [= delivered audio frames duration =],
+              {{MediaStreamTrackAudioStats/[[DeliveredFramesDelay]]}} is set to
+              [= delivered audio frames delay =],
+              {{MediaStreamTrackAudioStats/[[DroppedFrames]]}} is set to
+              [= dropped audio frames =] and
+              {{MediaStreamTrackAudioStats/[[DroppedFramesDuration]]}} is set to
+              [= dropped audio frames duration =].</p>
+              <div class="note">
+                <p>Only updating these counters once per task execution cycles
+                preserves the <a href=
+                "https://w3ctag.github.io/design-principles/#js-rtc">run-to-completion</a>
+                semantics defined in [[API-DESIGN-PRINCIPLES]].</p>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <section>
+          <h4>Attributes</h4>
+          <dl data-link-for="MediaStreamTrackAudioStats"
+          data-dfn-for="MediaStreamTrackAudioStats" class="attributes">
+            <dt>
+              <dfn data-idl="">deliveredFrames</dfn> of type <span class=
+              "idlMemberType">unsigned long long, readonly</span>
+            </dt>
+            <dd>
+              <p>
+                Upon getting, run the [= expose audio frame counters steps =]
+                and return
+                {{MediaStreamTrackAudioStats/[[DeliveredFrames]]}}.
+              </p>
+            </dd>
+            <dt>
+              <dfn data-idl="">deliveredFramesDuration</dfn> of type <span
+              class="idlMemberType">DOMHighResTimeStamp, readonly</span>
+            </dt>
+            <dd>
+              <p>
+                Upon getting, run the [= expose audio frame counters steps =]
+                and return
+                {{MediaStreamTrackAudioStats/[[DeliveredFramesDuration]]}}.
+              </p>
+            </dd>
+            <dt>
+              <dfn data-idl="">deliveredFramesDelay</dfn> of type <span
+              class="idlMemberType">DOMHighResTimeStamp, readonly</span>
+            </dt>
+            <dd>
+              <p>
+                Upon getting, run the [= expose audio frame counters steps =]
+                and return
+                {{MediaStreamTrackAudioStats/[[DeliveredFramesDelay]]}}.
+              </p>
+            </dd>
+            <dt>
+              <dfn data-idl="">droppedFrames</dfn> of type <span class=
+              "idlMemberType">unsigned long long, readonly</span>
+            </dt>
+            <dd>
+              <p>
+                Upon getting, run the [= expose audio frame counters steps =]
+                and return {{MediaStreamTrackAudioStats/[[DroppedFrames]]}}.
+              </p>
+            </dd>
+            <dt>
+              <dfn data-idl="">droppedFramesDuration</dfn> of type <span class=
+              "idlMemberType">DOMHighResTimeStamp, readonly</span>
+            </dt>
+            <dd>
+              <p>
+                Upon getting, run the [= expose audio frame counters steps =]
+                and return
+                {{MediaStreamTrackAudioStats/[[DroppedFramesDuration]]}}.
+              </p>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h4>Methods</h4>
+          <dl data-link-for="MediaStreamTrackAudioStats"
+          data-dfn-for="MediaStreamTrackAudioStats" class="methods">
+            <dt>
+              <dfn data-idl="">toJSON</dfn>
+            </dt>
+            <dd>
+              <p>
+                When called, run [[!WEBIDL]]'s [= default toJSON steps =].
+              </p>
+            </dd>
+          </dl>
+        </section>
+      </div>
     </section>
     <section>
       <h4>The MediaStreamTrackVideoStats interface</h4>
@@ -495,31 +689,31 @@ interface MediaStreamTrackVideoStats {
         <div>
           <p>The {{MediaStreamTrackVideoStats}} expose frame counters for the
           {{MediaStreamTrack}} that created it. For this track, the user agent
-          is required to count each frame from its source as follows:</p>
+          is required to count each video frame from its source as follows:</p>
           <ul>
             <li>
-              <p>A frame is considered
-              <dfn data-lt="delivered frames">delivered</dfn> if it either was
-              delivered to a sink or would have been delivered to a sink, if one
-              was connected. This is a subset of [= total frames =] and it is
-              incremented at the same time as [= total frames =].</p>
+              <p>A frame is considered a <dfn data-lt="delivered video frames">
+              delivered video frame</dfn> if it either was delivered to a sink
+              or would have been delivered to a sink, if one was connected. This
+              is a subset of [= total video frames =] and it is incremented at
+              the same time as [= total video frames =].</p>
             </li>
             <li>
-              <p>A frame is considered
-              <dfn data-lt="discarded frames">discarded</dfn> if it was
+              <p>A video frame is considered
+              <dfn data-lt="discarded video frames">discarded</dfn> if it was
               discarded in order to achieve the target
               {{MediaTrackSettings/frameRate}}. This is a subset of
-              [= total frames =] and it is incremented at the same time as
-              [= total frames =].</p>
+              [= total video frames =] and it is incremented at the same time as
+              [= total video frames =].</p>
             </li>
             <li>
-              <p>The <dfn data-lt="total frames">total</dfn> number of frames
-              that have been processed by this source, meaning it is known
-              whether the frame was considered delivered, discarded or dropped
-              for any other reason. The number of dropped frames for various
-              unknown reasons can be calculated by subtracting
-              [= delivered frames =] and [= discarded frames =] from
-              [= total frames =].</p>
+              <p>The <dfn data-lt="total video frames">total</dfn> number of
+              frames that have been processed by this source, meaning it is
+              known whether the frame was considered delivered, discarded or
+              dropped for any other reason. The number of dropped frames for
+              various unknown reasons can be calculated by subtracting
+              [= delivered video frames =] and [= discarded video frames =] from
+              [= total video frames =].</p>
               <div class="note">
                 <p>If the track is unmuted and enabled and the source is backed
                 by a camera, total frames is incremented by frames produced by
@@ -535,19 +729,19 @@ interface MediaStreamTrackVideoStats {
           <dfn class=export data-dfn-for="MediaStreamTrackVideoStats">[[\TotalFrames]]</dfn>,
           initialized to 0.
           </p>
-          <p>The <dfn data-lt="expose frame counters steps">expose frame
-          counters steps</dfn> are the following:</p>
+          <p>The <dfn data-lt="expose video frame counters steps">expose video
+          frame counters steps</dfn> are the following:</p>
           <ul>
             <li>
-              <p>If this is the first time the [= expose frame counters steps =]
-              are called for this {{MediaStreamTrackVideoStats}} in this task
-              execution cycle, set the internal slots of as follows:
+              <p>If this is the first time the [= expose video frame counters
+              steps =] are called for this {{MediaStreamTrackVideoStats}} in
+              this task execution cycle, set the internal slots of as follows:
               {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}} is set to
-              [= delivered frames =],
+              [= delivered video frames =],
               {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}} is set to
-              [= discarded frames =] and
+              [= discarded video frames =] and
               {{MediaStreamTrackVideoStats/[[TotalFrames]]}} is set to
-              [= total frames =].
+              [= total video frames =].
               </p>
               <div class="note">
                 <p>Only updating these counters once per task execution cycles
@@ -568,8 +762,8 @@ interface MediaStreamTrackVideoStats {
             </dt>
             <dd>
               <p>
-                Upon getting, run the [= expose frame counters steps =] and
-                return {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}}.
+                Upon getting, run the [= expose video frame counters steps =]
+                and return {{MediaStreamTrackVideoStats/[[DeliveredFrames]]}}.
               </p>
             </dd>
             <dt>
@@ -578,8 +772,8 @@ interface MediaStreamTrackVideoStats {
             </dt>
             <dd>
               <p>
-                Upon getting, run the [= expose frame counters steps =] and
-                return {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}}.
+                Upon getting, run the [= expose video frame counters steps =]
+                and return {{MediaStreamTrackVideoStats/[[DiscardedFrames]]}}.
               </p>
             </dd>
             <dt>
@@ -588,8 +782,8 @@ interface MediaStreamTrackVideoStats {
             </dt>
             <dd>
               <p>
-                Upon getting, run the [= expose frame counters steps =] and
-                return {{MediaStreamTrackVideoStats/[[TotalFrames]]}}.
+                Upon getting, run the [= expose video frame counters steps =]
+                and return {{MediaStreamTrackVideoStats/[[TotalFrames]]}}.
               </p>
             </dd>
           </dl>


### PR DESCRIPTION
Fixes #119.

This PR contains BOTH #117 and a fix for #119... I wanted to create a follow-up PR but I don't know how to create PR chains.

The only new thing that's not in #117 is `track.stats.latency`. I'll rebase this PR when #117 has merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/mediacapture-extensions/pull/120.html" title="Last updated on Oct 20, 2023, 8:32 AM UTC (8c45ba1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/120/1e287a8...henbos:8c45ba1.html" title="Last updated on Oct 20, 2023, 8:32 AM UTC (8c45ba1)">Diff</a>