### PR TITLE
Add current audio latency metric

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,9 +555,9 @@ interface MediaStreamTrackAudioStats {
               <p>The input latency is the estimated latency of the capture
               device, plus the latency added by buffering (if any) in the user
               agent and the time it takes the user agent to deliver the
-              frame(s). Note that once a frame has been delivered to a sink,
-              that sink may internally have its own latency (such as playout
-              delay) which is not included in this measurement.</p>
+              frame(s) to sinks. Note that once a frame has been delivered to a
+              sink, that sink may internally have its own latency (such as
+              playout delay) which is not included in this measurement.</p>
             </li>
           </ul>
           <p>Let the {{MediaStreamTrackAudioStats}} have internal slots

--- a/index.html
+++ b/index.html
@@ -423,8 +423,8 @@ partial interface MediaStreamTrack {
     <div>
       <p>
         On microphone audio tracks, frame counters allow the application to tell
-        the percentage of audio that is delivered as one quality indicator and
-        the latency metrics measure the input delay from capture to application.
+        the ratio of audio that is delivered as one quality indicator and the
+        latency metrics measure the input delay from capture to application.
       </p>
       <p>
         On camera and screenshare video tracks, frame counters allow the

--- a/index.html
+++ b/index.html
@@ -423,7 +423,8 @@ partial interface MediaStreamTrack {
     <div>
       <p>
         On microphone audio tracks, frame counters allow the application to tell
-        the percentage of audio that is delivered as one quality indicator.
+        the percentage of audio that is delivered as one quality indicator and
+        the latency metrics measure the input delay from capture to application.
       </p>
       <p>
         On camera and screenshare video tracks, frame counters allow the
@@ -547,7 +548,7 @@ interface MediaStreamTrackAudioStats {
               <p>The <dfn data-lt="delivered audio frames latency">delivered
               audio frames latency</dfn> is the sum of input latency (see
               [= current audio latency =]) of each of the [= delivered audio
-              frames =].</p>
+              frames =], in milliseconds.</p>
             </li>
             <li>
               <p>An audio frame that is discarded because it cannot be delivered

--- a/index.html
+++ b/index.html
@@ -558,7 +558,7 @@ interface MediaStreamTrackAudioStats {
               its sinks.</p>
               <div class="note">
                 <p>The user agent updates its estimates at sufficient frequency
-                to to allow monitoring. The latency is representative of the
+                to allow monitoring. The latency is representative of the
                 experienced delay, but is not necessarily an exact measurement
                 of the last individual audio frame that was delivered.</p>
                 <p>A sink that consumes audio may add additional processing

--- a/index.html
+++ b/index.html
@@ -509,7 +509,7 @@ interface MediaStreamTrackAudioStats {
   readonly attribute DOMHighResTimeStamp deliveredFramesDuration;
   readonly attribute unsigned long long totalFrames;
   readonly attribute DOMHighResTimeStamp totalFramesDuration;
-  readonly attribute DOMHighResTimeStamp? latency;
+  readonly attribute DOMHighResTimeStamp latency;
   [Default] object toJSON();
 };
         </pre>

--- a/index.html
+++ b/index.html
@@ -548,16 +548,19 @@ interface MediaStreamTrackAudioStats {
               not increase.</p>
             </div>
             <li>
-              <p>The <dfn data-lt="current audio latency">current audio
-              latency</dfn> is the current input latency, in milliseconds.
-              Before the input latency is known, such as before any audio frames
-              have been delivered, this value is <code>null</code>.</p>
-              <p>The input latency is the estimated latency of the capture
-              device, plus the latency added by buffering (if any) in the user
-              agent and the time it takes the user agent to deliver the
-              frame(s) to sinks. Note that once a frame has been delivered to a
-              sink, that sink may internally have its own latency (such as
-              playout delay) which is not included in this measurement.</p>
+              <p><dfn data-lt="input latency">Input latency</dfn> is the time,
+              in milliseconds, between the point in time an audio input device
+              has acquired a signal and the time it is available for
+              consumption, which may include buffering by the user agent.</p>
+              <p>The <dfn data-lt="latest input latency">latest input
+              latency</dfn> is the latest available [= input latency =] as
+              estimated between the track's input device and delivery to any of
+              its sinks.</p>
+              <div class="note">
+                <p>A sink that consumes audio may add additional processing
+                latency not included in this measurement, such as playout delay
+                or encode time.</p>
+              </div>
             </li>
           </ul>
           <p>Let the {{MediaStreamTrackAudioStats}} have internal slots
@@ -566,7 +569,7 @@ interface MediaStreamTrackAudioStats {
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFrames]]</dfn>,
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFramesDuration]]</dfn>,
           and
-          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\CurrentLatency]]</dfn>,
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\Latency]]</dfn>,
           initialized to 0.</p>
           <p>Let the {{MediaStreamTrackAudioStats}} also have an internal slot
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\CurrentTaskId]]</dfn>
@@ -595,8 +598,8 @@ interface MediaStreamTrackAudioStats {
               [= dropped audio frames =],
               set {{MediaStreamTrackAudioStats/[[DroppedFramesDuration]]}} to
               [= dropped audio frames duration =] and
-              set {{MediaStreamTrackAudioStats/[[CurrentLatency]]}} to
-              [= current audio latency =].</p>
+              set {{MediaStreamTrackAudioStats/[[Latency]]}} to the
+              [= latest input latency =].</p>
               <div class="note">
                 <p>Only updating these counters once per task preserves the
                 <a href="https://w3ctag.github.io/design-principles/#js-rtc">
@@ -673,7 +676,7 @@ interface MediaStreamTrackAudioStats {
             <dd>
               <p>
                 Upon getting, run the [= expose audio frame counters steps =]
-                and return {{MediaStreamTrackAudioStats/[[CurrentLatency]]}}.
+                and return {{MediaStreamTrackAudioStats/[[Latency]]}}.
               </p>
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -535,17 +535,19 @@ interface MediaStreamTrackAudioStats {
               latency</dfn> is the input latency of the last audio frame that
               was delivered, in milliseconds. If no audio frames have been
               delivered yet, this value is <code>null</code>.</p>
+              <p>The input latency is the estimated latency of the capture
+              device plus the time time it takes the user agent to deliver that
+              frame. This measurement is incremented at the same time as
+              [= delivered audio frames =] and is measured in milliseconds. Note
+              that once a frame has been delivered to a sink, that sink may
+              internally have its own latency (such as playout delay) which is
+              not included in this measurement</p>
             </li>
             <li>
               <p>The <dfn data-lt="delivered audio frames latency">delivered
-              audio frames latency</dfn> is the sum of [= delivered audio
-              frames =]'s input latency. The input latency is the estimated
-              latency of the capture device plus the time time it takes the user
-              agent to deliver that frame. This measurement is incremented at
-              the same time as [= delivered audio frames =] and is measured in
-              milliseconds. Note that once a frame has been delivered to a sink,
-              that sink may internally have its own latency (such as playout
-              delay) which is not included in this measurement.</p>
+              audio frames latency</dfn> is the sum of input latency (see
+              [= current audio latency =]) of each of the [= delivered audio
+              frames =].</p>
             </li>
             <li>
               <p>An audio frame that is discarded because it cannot be delivered

--- a/index.html
+++ b/index.html
@@ -538,17 +538,18 @@ interface MediaStreamTrackAudioStats {
               delivered yet, this value is <code>null</code>.</p>
               <p>The input latency is the estimated latency of the capture
               device plus the time time it takes the user agent to deliver that
-              frame. This measurement is incremented at the same time as
-              [= delivered audio frames =] and is measured in milliseconds. Note
-              that once a frame has been delivered to a sink, that sink may
-              internally have its own latency (such as playout delay) which is
-              not included in this measurement</p>
+              frame. If the user agent buffers audio internally before
+              delivering, the length of the buffer is included in the latency
+              measurement. Note that once a frame has been delivered to a sink,
+              that sink may internally have its own latency (such as playout
+              delay) which is not included in this measurement.</p>
             </li>
             <li>
               <p>The <dfn data-lt="delivered audio frames latency">delivered
               audio frames latency</dfn> is the sum of input latency (see
               [= current audio latency =]) of each of the [= delivered audio
-              frames =], in milliseconds.</p>
+              frames =], in milliseconds. This measurement is incremented at the
+              same time as [= delivered audio frames =].</p>
             </li>
             <li>
               <p>An audio frame that is discarded because it cannot be delivered

--- a/index.html
+++ b/index.html
@@ -559,7 +559,6 @@ interface MediaStreamTrackAudioStats {
               that sink may internally have its own latency (such as playout
               delay) which is not included in this measurement.</p>
             </li>
-            </li>
           </ul>
           <p>Let the {{MediaStreamTrackAudioStats}} have internal slots
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFrames]]</dfn>,

--- a/index.html
+++ b/index.html
@@ -557,6 +557,10 @@ interface MediaStreamTrackAudioStats {
               estimated between the track's input device and delivery to any of
               its sinks.</p>
               <div class="note">
+                <p>The user agent updates its estimates at sufficient frequency
+                to to allow monitoring. The latency is representative of the
+                experienced delay, but is not necessarily an exact measurement
+                of the last individual audio frame that was delivered.</p>
                 <p>A sink that consumes audio may add additional processing
                 latency not included in this measurement, such as playout delay
                 or encode time.</p>

--- a/index.html
+++ b/index.html
@@ -506,6 +506,8 @@ partial interface MediaStreamTrack {
 interface MediaStreamTrackAudioStats {
   readonly attribute unsigned long long deliveredFrames;
   readonly attribute DOMHighResTimeStamp deliveredFramesDuration;
+  readonly attribute DOMHighResTimeStamp? latency;
+  readonly attribute DOMHighResTimeStamp deliveredFramesLatency;
   readonly attribute unsigned long long totalFrames;
   readonly attribute DOMHighResTimeStamp totalFramesDuration;
   [Default] object toJSON();
@@ -529,6 +531,23 @@ interface MediaStreamTrackAudioStats {
               milliseconds.</p>
             </li>
             <li>
+              <p>The <dfn data-lt="current audio latency">current audio
+              latency</dfn> is the input latency of the last audio frame that
+              was delivered, in milliseconds. If no audio frames have been
+              delivered yet, this value is <code>null</code>.</p>
+            </li>
+            <li>
+              <p>The <dfn data-lt="delivered audio frames latency">delivered
+              audio frames latency</dfn> is the sum of [= delivered audio
+              frames =]'s input latency. The input latency is the estimated
+              latency of the capture device plus the time time it takes the user
+              agent to deliver that frame. This measurement is incremented at
+              the same time as [= delivered audio frames =] and is measured in
+              milliseconds. Note that once a frame has been delivered to a sink,
+              that sink may internally have its own latency (such as playout
+              delay) which is not included in this measurement.</p>
+            </li>
+            <li>
               <p>An audio frame that is discarded because it cannot be delivered
               on time, or it cannot be delivered for any other reason, is
               considered <dfn data-lt="dropped audio frames">dropped</dfn>.</p>
@@ -550,6 +569,8 @@ interface MediaStreamTrackAudioStats {
           <p>Let the {{MediaStreamTrackAudioStats}} have internal slots
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFrames]]</dfn>,
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesDuration]]</dfn>,
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\CurrentLatency]]</dfn>,
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesLatency]]</dfn>,
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFrames]]</dfn>,
           and
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFramesDuration]]</dfn>,
@@ -565,6 +586,10 @@ interface MediaStreamTrackAudioStats {
               [= delivered audio frames =],
               {{MediaStreamTrackAudioStats/[[DeliveredFramesDuration]]}} is set
               to [= delivered audio frames duration =],
+              {{MediaStreamTrackAudioStats/[[CurrentLatency]]}} is set
+              to [= current audio latency =],
+              {{MediaStreamTrackAudioStats/[[DeliveredFramesLatency]]}} is set
+              to [= delivered audio frames latency =],
               {{MediaStreamTrackAudioStats/[[DroppedFrames]]}} is set to
               [= dropped audio frames =] and
               {{MediaStreamTrackAudioStats/[[DroppedFramesDuration]]}} is set to
@@ -602,6 +627,29 @@ interface MediaStreamTrackAudioStats {
                 Upon getting, run the [= expose audio frame counters steps =]
                 and return
                 {{MediaStreamTrackAudioStats/[[DeliveredFramesDuration]]}}.
+              </p>
+            </dd>
+            <dt>
+              <dfn data-idl="">latency</dfn> of type <span
+              class="idlMemberType">DOMHighResTimeStamp, readonly,
+              nullable</span>
+            </dt>
+            <dd>
+              <p>
+                Upon getting, run the [= expose audio frame counters steps =]
+                and return
+                {{MediaStreamTrackAudioStats/[[CurrentLatency]]}}.
+              </p>
+            </dd>
+            <dt>
+              <dfn data-idl="">deliveredFramesLatency</dfn> of type <span
+              class="idlMemberType">DOMHighResTimeStamp, readonly</span>
+            </dt>
+            <dd>
+              <p>
+                Upon getting, run the [= expose audio frame counters steps =]
+                and return
+                {{MediaStreamTrackAudioStats/[[DeliveredFramesLatency]]}}.
               </p>
             </dd>
             <dt>

--- a/index.html
+++ b/index.html
@@ -537,12 +537,11 @@ interface MediaStreamTrackAudioStats {
               was delivered, in milliseconds. If no audio frames have been
               delivered yet, this value is <code>null</code>.</p>
               <p>The input latency is the estimated latency of the capture
-              device plus the time time it takes the user agent to deliver that
-              frame. If the user agent buffers audio internally before
-              delivering, the length of the buffer is included in the latency
-              measurement. Note that once a frame has been delivered to a sink,
-              that sink may internally have its own latency (such as playout
-              delay) which is not included in this measurement.</p>
+              device, plus the latency added by buffering (if any) in the user
+              agent and the time it takes the user agent to deliver that frame.
+              Note that once a frame has been delivered to a sink, that sink may
+              internally have its own latency (such as playout delay) which is
+              not included in this measurement.</p>
             </li>
             <li>
               <p>The <dfn data-lt="delivered audio frames latency">delivered

--- a/index.html
+++ b/index.html
@@ -507,10 +507,9 @@ partial interface MediaStreamTrack {
 interface MediaStreamTrackAudioStats {
   readonly attribute unsigned long long deliveredFrames;
   readonly attribute DOMHighResTimeStamp deliveredFramesDuration;
-  readonly attribute DOMHighResTimeStamp? latency;
-  readonly attribute DOMHighResTimeStamp deliveredFramesLatency;
   readonly attribute unsigned long long totalFrames;
   readonly attribute DOMHighResTimeStamp totalFramesDuration;
+  readonly attribute DOMHighResTimeStamp? latency;
   [Default] object toJSON();
 };
         </pre>
@@ -532,25 +531,6 @@ interface MediaStreamTrackAudioStats {
               milliseconds.</p>
             </li>
             <li>
-              <p>The <dfn data-lt="current audio latency">current audio
-              latency</dfn> is the input latency of the last audio frame that
-              was delivered, in milliseconds. If no audio frames have been
-              delivered yet, this value is <code>null</code>.</p>
-              <p>The input latency is the estimated latency of the capture
-              device, plus the latency added by buffering (if any) in the user
-              agent and the time it takes the user agent to deliver that frame.
-              Note that once a frame has been delivered to a sink, that sink may
-              internally have its own latency (such as playout delay) which is
-              not included in this measurement.</p>
-            </li>
-            <li>
-              <p>The <dfn data-lt="delivered audio frames latency">delivered
-              audio frames latency</dfn> is the sum of input latency (see
-              [= current audio latency =]) of each of the [= delivered audio
-              frames =], in milliseconds. This measurement is incremented at the
-              same time as [= delivered audio frames =].</p>
-            </li>
-            <li>
               <p>An audio frame that is discarded because it cannot be delivered
               on time, or it cannot be delivered for any other reason, is
               considered <dfn data-lt="dropped audio frames">dropped</dfn>.</p>
@@ -567,16 +547,27 @@ interface MediaStreamTrackAudioStats {
               such as if the track is muted or disabled, then the counters do
               not increase.</p>
             </div>
+            <li>
+              <p>The <dfn data-lt="current audio latency">current audio
+              latency</dfn> is the current input latency, in milliseconds.
+              Before the input latency is known, such as before any audio frames
+              have been delivered, this value is <code>null</code>.</p>
+              <p>The input latency is the estimated latency of the capture
+              device, plus the latency added by buffering (if any) in the user
+              agent and the time it takes the user agent to deliver the
+              frame(s). Note that once a frame has been delivered to a sink,
+              that sink may internally have its own latency (such as playout
+              delay) which is not included in this measurement.</p>
+            </li>
             </li>
           </ul>
           <p>Let the {{MediaStreamTrackAudioStats}} have internal slots
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFrames]]</dfn>,
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesDuration]]</dfn>,
-          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\CurrentLatency]]</dfn>,
-          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DeliveredFramesLatency]]</dfn>,
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFrames]]</dfn>,
-          and
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\DroppedFramesDuration]]</dfn>,
+          and
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\CurrentLatency]]</dfn>,
           initialized to 0.</p>
           <p>Let the {{MediaStreamTrackAudioStats}} also have an internal slot
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\CurrentTaskId]]</dfn>
@@ -601,14 +592,12 @@ interface MediaStreamTrackAudioStats {
               [= delivered audio frames =],
               set {{MediaStreamTrackAudioStats/[[DeliveredFramesDuration]]}}
               to [= delivered audio frames duration =],
-              set {{MediaStreamTrackAudioStats/[[CurrentLatency]]}} to
-              [= current audio latency =],
-              set {{MediaStreamTrackAudioStats/[[DeliveredFramesLatency]]}} to
-              [= delivered audio frames latency =],
               set {{MediaStreamTrackAudioStats/[[DroppedFrames]]}} to
-              [= dropped audio frames =] and
+              [= dropped audio frames =],
               set {{MediaStreamTrackAudioStats/[[DroppedFramesDuration]]}} to
-              [= dropped audio frames duration =].</p>
+              [= dropped audio frames duration =] and
+              set {{MediaStreamTrackAudioStats/[[CurrentLatency]]}} to
+              [= current audio latency =].</p>
               <div class="note">
                 <p>Only updating these counters once per task preserves the
                 <a href="https://w3ctag.github.io/design-principles/#js-rtc">
@@ -645,29 +634,6 @@ interface MediaStreamTrackAudioStats {
               </p>
             </dd>
             <dt>
-              <dfn data-idl="">latency</dfn> of type <span
-              class="idlMemberType">DOMHighResTimeStamp, readonly,
-              nullable</span>
-            </dt>
-            <dd>
-              <p>
-                Upon getting, run the [= expose audio frame counters steps =]
-                and return
-                {{MediaStreamTrackAudioStats/[[CurrentLatency]]}}.
-              </p>
-            </dd>
-            <dt>
-              <dfn data-idl="">deliveredFramesLatency</dfn> of type <span
-              class="idlMemberType">DOMHighResTimeStamp, readonly</span>
-            </dt>
-            <dd>
-              <p>
-                Upon getting, run the [= expose audio frame counters steps =]
-                and return
-                {{MediaStreamTrackAudioStats/[[DeliveredFramesLatency]]}}.
-              </p>
-            </dd>
-            <dt>
               <dfn data-idl="">totalFrames</dfn> of type <span class=
               "idlMemberType">unsigned long long, readonly</span>
             </dt>
@@ -699,6 +665,17 @@ interface MediaStreamTrackAudioStats {
                 {{MediaStreamTrackAudioStats/deliveredFramesDuration}} /
                 {{MediaStreamTrackAudioStats/totalFramesDuration}}.</p>
               </div>
+            </dd>
+            <dt>
+              <dfn data-idl="">latency</dfn> of type <span
+              class="idlMemberType">DOMHighResTimeStamp, readonly,
+              nullable</span>
+            </dt>
+            <dd>
+              <p>
+                Upon getting, run the [= expose audio frame counters steps =]
+                and return {{MediaStreamTrackAudioStats/[[CurrentLatency]]}}.
+              </p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Fixes #119.

Part of #96. See also follow up #128.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/mediacapture-extensions/pull/124.html" title="Last updated on Nov 22, 2023, 12:30 PM UTC (461286a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/124/48d3e26...henbos:461286a.html" title="Last updated on Nov 22, 2023, 12:30 PM UTC (461286a)">Diff</a>