### PR TITLE
Typo fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -990,7 +990,7 @@ const [videoTrack] = stream.getVideoTracks();
 
 // Try to improve framing.
 const capabilities = videoTrack.getCapabilities();
-if (("faceFraming" in capabilities) {
+if ("faceFraming" in capabilities) {
   await videoTrack.applyConstraints({faceFraming: true});
 } else {
   // Face framing is not supported by the platform or by the camera.


### PR DESCRIPTION
Copied an example and found a typo.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ch1sKey/mediacapture-extensions/pull/133.html" title="Last updated on Nov 24, 2023, 8:17 AM UTC (73c313c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/133/42cf948...Ch1sKey:73c313c.html" title="Last updated on Nov 24, 2023, 8:17 AM UTC (73c313c)">Diff</a>