### PR TITLE
Add feature at risk note on audio frame counters

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,13 +518,11 @@ interface MediaStreamTrackAudioStats {
 };
         </pre>
         <div class="note">
-          <p>The audio frame counters and durations
+          <p>The following metrics lack Working Group consensus:
           ({{MediaStreamTrackAudioStats/deliveredFrames}},
           {{MediaStreamTrackAudioStats/deliveredFramesDuration}},
           {{MediaStreamTrackAudioStats/totalFrames}} and
-          {{MediaStreamTrackAudioStats/totalFramesDuration}}) allowing the
-          application to measure audio glitches (dropped = total - delivered)
-          are at risk due to lack of consensus, see <a
+          {{MediaStreamTrackAudioStats/totalFramesDuration}}). See <a
           href="https://github.com/w3c/mediacapture-extensions/issues/129">Issue
           #129</a>.</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -517,6 +517,17 @@ interface MediaStreamTrackAudioStats {
   [Default] object toJSON();
 };
         </pre>
+        <div class="note">
+          <p>The audio frame counters and durations
+          ({{MediaStreamTrackAudioStats/deliveredFrames}},
+          {{MediaStreamTrackAudioStats/deliveredFramesDuration}},
+          {{MediaStreamTrackAudioStats/totalFrames}} and
+          {{MediaStreamTrackAudioStats/totalFramesDuration}}) allowing the
+          application to measure audio glitches (dropped = total - delivered)
+          are at risk due to lack of consensus, see <a
+          href="https://github.com/w3c/mediacapture-extensions/issues/129">Issue
+          #129</a>.</p>
+        </div>
         <div>
           <p>The {{MediaStreamTrackAudioStats}} expose frame counters for the
           {{MediaStreamTrack}} that created it. For this track, the user agent

--- a/index.html
+++ b/index.html
@@ -519,10 +519,10 @@ interface MediaStreamTrackAudioStats {
         </pre>
         <div class="note">
           <p>The following metrics lack Working Group consensus:
-          ({{MediaStreamTrackAudioStats/deliveredFrames}},
+          {{MediaStreamTrackAudioStats/deliveredFrames}},
           {{MediaStreamTrackAudioStats/deliveredFramesDuration}},
           {{MediaStreamTrackAudioStats/totalFrames}} and
-          {{MediaStreamTrackAudioStats/totalFramesDuration}}). See <a
+          {{MediaStreamTrackAudioStats/totalFramesDuration}}. See <a
           href="https://github.com/w3c/mediacapture-extensions/issues/129">Issue
           #129</a>.</p>
         </div>


### PR DESCRIPTION
Documenting "at risk" with reference to #129 as to not give a false impression of standards maturity.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/mediacapture-extensions/pull/135.html" title="Last updated on Dec 21, 2023, 3:33 PM UTC (0f03792)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/135/6d1a482...henbos:0f03792.html" title="Last updated on Dec 21, 2023, 3:33 PM UTC (0f03792)">Diff</a>