### PR TITLE
Clarify how resetLatency() relates to run-to-completion semantics.

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,8 +584,8 @@ interface MediaStreamTrackAudioStats {
               <dfn data-lt="minimum input latency">minimum input latency</dfn>
               and <dfn data-lt="maximum input latency">maximum input
               latency</dfn> which are the average, minimum and maximum observed
-              measurements since the last <dfn data-lt="latency reset">latency
-              reset</dfn>.
+              measurements since the last <dfn data-lt="latency reset time">
+              latency reset time</dfn>.
               </p>
             </li>
           </ul>
@@ -600,8 +600,10 @@ interface MediaStreamTrackAudioStats {
           and
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\MaximumLatency]]</dfn>,
           initialized to 0.</p>
-          <p>Let the {{MediaStreamTrackAudioStats}} also have an internal slot
+          <p>Let the {{MediaStreamTrackAudioStats}} also have internal slots
           <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\LastTask]]</dfn>
+          and
+          <dfn class=export data-dfn-for="MediaStreamTrackAudioStats">[[\LastExposureTime]]</dfn>,
           initialized to <code>undefined</code>.</p>
           <p>The <dfn data-lt="expose audio frame counters steps">expose audio
           frame counters steps</dfn> are the following:</p>
@@ -634,6 +636,8 @@ interface MediaStreamTrackAudioStats {
               [= minimum input latency =] and
               set {{MediaStreamTrackAudioStats/[[MaximumLatency]]}} to the
               [= maximum input latency =].</p>
+              <p>Update {{MediaStreamTrackAudioStats/[[LastExposureTime]]}} to
+              reflect the time that these metrics were exposed.</p>
               <div class="note">
                 <p>Only updating these counters once per [=task=] preserves the
                 <a href="https://w3ctag.github.io/design-principles/#js-rtc">
@@ -764,7 +768,8 @@ interface MediaStreamTrackAudioStats {
                   {{MediaStreamTrackAudioStats/[[Latency]]}}.</p>
                 </li>
                 <li>
-                  <p>Perform a [= latency reset =].</p>
+                  <p>Set the [= latency reset time =] to
+                  {{MediaStreamTrackAudioStats/[[LastExposureTime]]}}.</p>
                 </li>
               </ul>
               </p>

--- a/index.html
+++ b/index.html
@@ -636,7 +636,7 @@ interface MediaStreamTrackAudioStats {
               [= minimum input latency =] and
               set {{MediaStreamTrackAudioStats/[[MaximumLatency]]}} to the
               [= maximum input latency =].</p>
-              <p>Update {{MediaStreamTrackAudioStats/[[LastExposureTime]]}} to
+              <p>Set {{MediaStreamTrackAudioStats/[[LastExposureTime]]}} to
               reflect the time that these metrics were exposed.</p>
               <div class="note">
                 <p>Only updating these counters once per [=task=] preserves the


### PR DESCRIPTION
Fixes #136.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/henbos/mediacapture-extensions/pull/137.html" title="Last updated on Jan 18, 2024, 3:21 PM UTC (98f69ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/137/7421d0c...henbos:98f69ae.html" title="Last updated on Jan 18, 2024, 3:21 PM UTC (98f69ae)">Diff</a>