### PR TITLE
Add background segmentation mask

### DIFF
--- a/index.html
+++ b/index.html
@@ -1972,5 +1972,107 @@ partial interface MediaStream {
 };</pre>
     </div>
   </section>
+  <section>
+    <h2>Background segmentation mask</h2>
+    <p>Some platforms or User Agents may provide built-in support for background segmentation of video frames, in particular for camera video streams.
+       Web applications may want to control whether background segmentation is computed at the source level and to get access to the computed segmentation masks.
+       This allows the web application for instance
+       to do custom framing or background blurring or replacement
+       while leveraging on platform computed background segmentation.
+       This allows the web application
+       to access the original unmodified frame and
+       to fine tune frame modifications based on its likings.
+       For that reason, we extend {{MediaStreamTrack}} with the following properties and {{VideoFrameMetadata}} with the following attributes.
+    </p>
+    <pre class="idl">
+partial dictionary MediaTrackSupportedConstraints {
+  boolean backgroundSegmentationMask = true;
+};
+
+partial dictionary MediaTrackConstraintSet {
+  ConstrainBoolean backgroundSegmentationMask;
+};
+
+partial dictionary MediaTrackSettings {
+  boolean backgroundSegmentationMask;
+};
+
+partial dictionary MediaTrackCapabilities {
+  sequence&lt;boolean&gt; backgroundSegmentationMask;
+};</pre>
+    <section>
+      <h3>{{VideoFrameMetadata}}</h3>
+      <pre class="idl">
+partial dictionary VideoFrameMetadata {
+  ImageBitmap backgroundSegmentationMask;
+};</pre>
+      <section class="notoc">
+        <h4>Members</h4>
+        <dl class="dictionary-members" data-link-for="VideoFrameMetadata" data-dfn-for="VideoFrameMetadata">
+          <dt><dfn><code>backgroundSegmentationMask</code></dfn> of type <code>{{ImageBitmap}}</code></dt>
+          <dd>
+            <p>A background segmentation mask with
+               white denoting certainly foreground,
+               black denoting certainly background and
+               grey denoting uncertainty or ambiguity with
+               light shades of grey denoting likely foreground and
+               dark shades of grey denoting likely background.
+               Absence might indicate
+               that the frame is not from a camera, or
+               that the user agent does not support or
+               was not able to do background segmentation.
+            </p>
+          </dd>
+        </dl>
+      </section>
+    </section>
+    <section>
+      <h3>Example</h3>
+      <pre class="example">
+// Open camera.
+const stream = await navigator.mediaDevices.getUserMedia({video: true});
+const [videoTrack] = stream.getVideoTracks();
+
+// Try to enable background segmentation mask.
+const videoCapabilities = videoTrack.getCapabilities();
+if ((videoCapabilities.backgroundSegmentationMask || []).includes(true)) {
+  await videoTrack.applyConstraints({backgroundSegmentationMask: {exact: true}});
+} else {
+  // Background segmentation mask is not supported by the platform or
+  // by the camera. Consider falling back to some other method.
+}
+
+const canvasContext = document.querySelector('canvas').getContext('2d');
+const videoProcessor = new MediaStreamTrackProcessor({track: videoTrack});
+const videoProcessorReader = videoProcessor.readable.getReader();
+
+for (;;) {
+  const {done, value: videoFrame} = await videoProcessorReader.read();
+  if (done)
+    break;
+  const {backgroundSegmentationMask} = videoFrame.metadata();
+  if (backgroundSegmentationMask) {
+    // Draw the video frame.
+    canvasContext.globalCompositeOperation = 'copy';
+    context.drawImage(videoFrame, 0, 0);
+    // Draw (or multiply with) the mask.
+    // The result is the foreground on black.
+    context.globalCompositeOperation = 'multiply';
+    canvasContext.drawImage(backgroundSegmentationMask, 0, 0);
+  }
+  else {
+    // Everything is background. Fill with black.
+    canvasContext.globalCompositeOperation = 'copy';
+    canvasContext.fillStyle = 'black';
+    canvasContext.fillRect(
+      0,
+      0,
+      canvasContext.canvas.width,
+      canvasContext.canvas.height);
+  }
+}
+      </pre>
+    </section>
+  </section>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2029,48 +2029,57 @@ partial dictionary VideoFrameMetadata {
     <section>
       <h3>Example</h3>
       <pre class="example">
+// main.js:
 // Open camera.
 const stream = await navigator.mediaDevices.getUserMedia({video: true});
-const [videoTrack] = stream.getVideoTracks();
+const [track] = stream.getVideoTracks();
+// Do video processing in a worker.
+const worker = new Worker('worker.js');
+worker.postMessage({track}, [track]);
+const {data} = await new Promise(result => worker.onmessage = result);
+const videoElement = document.querySelector('video');
+videoElement.srcObject = new MediaStream([data.track]);
 
-// Try to enable background segmentation mask.
-const videoCapabilities = videoTrack.getCapabilities();
-if ((videoCapabilities.backgroundSegmentationMask || []).includes(true)) {
-  await videoTrack.applyConstraints({backgroundSegmentationMask: {exact: true}});
-} else {
-  // Background segmentation mask is not supported by the platform or
-  // by the camera. Consider falling back to some other method.
-}
-
-const canvasContext = document.querySelector('canvas').getContext('2d');
-const videoProcessor = new MediaStreamTrackProcessor({track: videoTrack});
-const videoProcessorReader = videoProcessor.readable.getReader();
-
-for (;;) {
-  const {done, value: videoFrame} = await videoProcessorReader.read();
-  if (done)
-    break;
-  const {backgroundSegmentationMask} = videoFrame.metadata();
-  if (backgroundSegmentationMask) {
-    // Draw the video frame.
-    canvasContext.globalCompositeOperation = 'copy';
-    context.drawImage(videoFrame, 0, 0);
-    // Draw (or multiply with) the mask.
-    // The result is the foreground on black.
-    context.globalCompositeOperation = 'multiply';
-    canvasContext.drawImage(backgroundSegmentationMask, 0, 0);
+// worker.js:
+onmessage = async ({data: {track}}) => {
+  // Try to enable background segmentation mask.
+  const capabilities = track.getCapabilities();
+  if (capabilities.backgroundSegmentationMask?.includes(true)) {
+    await track.applyConstraints({backgroundSegmentationMask: {exact: true}});
+  } else {
+    // Background segmentation mask is not supported by the platform or
+    // by the camera. Consider falling back to some other method.
   }
-  else {
-    // Everything is background. Fill with black.
-    canvasContext.globalCompositeOperation = 'copy';
-    canvasContext.fillStyle = 'black';
-    canvasContext.fillRect(
-      0,
-      0,
-      canvasContext.canvas.width,
-      canvasContext.canvas.height);
-  }
-}
+  const trackGenerator = new VideoTrackGenerator();
+  self.postMessage({track: trackGenerator.track}, [trackGenerator.track]);
+  const {readable} = new MediaStreamTrackProcessor({track});
+
+  const canvas = new OffscreenCanvas(640, 480);
+  const context = canvas.getContext('2d', {desynchronized: true});
+
+  const transformer = new TransformStream({
+    async transform(frame, controller) {
+      const {backgroundSegmentationMask} = frame.metadata();
+      if (backgroundSegmentationMask) {
+        // Draw the video frame.
+        context.globalCompositeOperation = 'copy';
+        context.drawImage(frame, 0, 0);
+        // Draw (or multiply with) the mask.
+        // The result is the foreground on black.
+        context.globalCompositeOperation = 'multiply';
+        context.drawImage(backgroundSegmentationMask, 0, 0);
+      } else {
+        // Everything is background. Fill with black.
+        context.globalCompositeOperation = 'copy';
+        context.fillStyle = 'black';
+        context.fillRect(0, 0, canvas.width, canvas.height);
+      }
+      controller.enqueue(new VideoFrame(canvas, {timestamp: frame.timestamp}));
+      frame.close();
+    }
+  });
+  await readable.pipeThrough(transformer).pipeTo(trackGenerator.writable);
+};
       </pre>
     </section>
   </section>


### PR DESCRIPTION
Hi!

This adds capabilities, constraints and settings for background segmentation mask. Those are fairly obvious.

For the feature to be useful, the actual background segmentation mask must be provided to web apps. There are various ways to do that:
1. In my PoC, I changed the stream of video frames to be a stream of interleaved background segmentation mask and real video frames and extended video frame metadata with a background segmentation mask flag so that web apps can tell segmentation mask and real video frames apart.
   However, that makes it awkward to process such streams and very unclear how to encode them.
2. In this PR, the real video frame and background segmentation mask frame are bundled together which simplifies processing of the streams and allows encoders to encode real video frames normally. The background segmentation mask frames for their part are mostly for local consumption only.
3. Another option would be to utilize an alpha channel. However, there are problems with that approach:
   - Some pixel formats (such as NV12 and NV21) do not have corresponding alpha channel formats. So it would not be possible to such add an alpha channel and then later to drop it in order to get the original frame. Instead of that, the whole frame would have to be converted to a difference format.
   - There are no canvas composite operations, for instance, to operate with alpha masks whereas they work great with grayscale masks.
   - Pixels which are certainly background would be completely transparent. For completely transparent pixel the color is practically irrelevant and some compression algorithms could group all completely transparent pixel together and thus lose color information.

/cc @riju


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eehakkin/intel-w3c-mediacapture-extensions/pull/142.html" title="Last updated on May 20, 2025, 2:46 PM UTC (7be8095)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/142/4a1d9d6...eehakkin:7be8095.html" title="Last updated on May 20, 2025, 2:46 PM UTC (7be8095)">Diff</a>