### PR TITLE
Capture, receive, and RTP timestamp concept definitions & normative requirements for gUM/gDM

### DIFF
--- a/index.html
+++ b/index.html
@@ -1157,12 +1157,13 @@ interface MediaStreamTrackVideoStats {
     <section class="informative">
       <h2>Video timestamp concepts</h2>
       <p>
-        Video media flowing inside media stream tracks comprise of a sequence of video frames, where
+        Video media flowing inside media stream tracks comprises of a sequence of video frames, where
         the frames are sampled from the media at instants spread out over time.
       </p>
       <p>
         Each video frame has a <dfn class="export">presentation timestamp</dfn>
-        which is relative to the first frame appearing on the track. The timestamp
+        which is relative to the first frame appearing on the track. The [=presentation timestamp=]
+        of the first video frame appearing on the track is 0. The timestamp
         is present for sinks to be able to define an absolute timeline of the frames
         relative to a clock reference. A source of frames can define how this timestamp
         is set. A sink of frames can define how this timestamp is used.
@@ -1218,16 +1219,16 @@ partial dictionary VideoFrameMetadata {
         </dl>
       </section>
       <h3>Algorithms</h3>
-      The <dfn class="abstract-op">Initialize Video Frame Timestamps From Internal MediaStreamTrack Video Frame</dfn>
-      algorithm runs with |frame| as input.
+      When the <dfn class="abstract-op">Initialize Video Frame Timestamps From Internal MediaStreamTrack Video Frame</dfn>
+      algorithm is invoked with |frame| as input, run the following steps.
       <ol class=algorithm>
         <li>Set {{VideoFrame/timestamp}} from [=presentation timestamp=].</li>
         <li>Set {{VideoFrameMetadata/captureTime}} from [=capture timestamp=] if set.</li>
         <li>Set {{VideoFrameMetadata/receiveTime}} from [=receive timestamp=] if set.</li>
         <li>Set {{VideoFrameMetadata/rtpTimestamp}} from [=RTP timestamp=] if set.</li>
       </ol>
-      The <dfn class="abstract-op">Copy Video Frame Timestamps To Internal MediaStreamTrack Video Frame</dfn>
-      algorithm runs with |frame| as input.
+      When the <dfn class="abstract-op">Copy Video Frame Timestamps To Internal MediaStreamTrack Video Frame</dfn>
+      algorithm runs with |frame| as input, run the following steps.
       <ol class=algorithm>
         <li>Set [=presentation timestamp=] from {{VideoFrame/timestamp}}.</li>
         <li>Set [=capture timestamp=] from {{VideoFrameMetadata/captureTime}} if [=map/exist|present=].</li>

--- a/index.html
+++ b/index.html
@@ -1250,7 +1250,7 @@ partial dictionary VideoFrameMetadata {
       <p>
         The user agent MUST set the [=capture timestamp=] of each video frame that is sourced from
         {{MediaDevices/getUserMedia()}} and {{MediaDevices/getDisplayMedia()}} to its best estimate of the time that
-        the frame was captured, which MUST be in the past relative to the time the frame is appearing on the track.
+        the frame was captured.
         This value MUST be monotonically increasing.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -1220,7 +1220,7 @@ partial dictionary VideoFrameMetadata {
       <h3>Algorithms</h3>
       The <dfn class="abstract-op">Initialize Video Frame Timestamps From Internal MediaStreamTrack Video Frame</dfn>
       algorithm runs with |frame| as input.
-      <ol>
+      <ol class=algorithm>
         <li>Set {{VideoFrame/timestamp}} from [=presentation timestamp=].</li>
         <li>Set {{VideoFrameMetadata/captureTime}} from [=capture timestamp=] if set.</li>
         <li>Set {{VideoFrameMetadata/receiveTime}} from [=receive timestamp=] if set.</li>

--- a/index.html
+++ b/index.html
@@ -1218,7 +1218,7 @@ partial dictionary VideoFrameMetadata {
         </dl>
       </section>
       <h3>Algorithms</h3>
-      The <dfn class="export">Initialize Video Frame Timestamps From Internal MediaStreamTrack Video Frame</dfn>
+      The <dfn class="abstract-op">Initialize Video Frame Timestamps From Internal MediaStreamTrack Video Frame</dfn>
       algorithm runs with |frame| as input.
       <ol>
         <li>Set {{VideoFrame/timestamp}} from [=presentation timestamp=].</li>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
   var respecConfig = {
     group: "webrtc",
-    xref: ["geometry-1", "html", "infra", "permissions", "dom", "image-capture", "mediacapture-streams", "webaudio", "webcodecs", "webidl"],
+    xref: ["geometry-1", "html", "infra", "permissions", "dom", "hr-time", "image-capture", "mediacapture-streams", "screen-capture", "webaudio", "webcodecs", "webidl"],
     edDraftURI: "https://w3c.github.io/mediacapture-extensions/",
     editors:  [
       {name: "Jan-Ivar Bruaroey", company: "Mozilla Corporation", w3cid: 79152},
@@ -1159,14 +1159,15 @@ interface MediaStreamTrackVideoStats {
       <h2>Capture timestamps</h2>
       <div>
         <p>
+          [[mediacapture-fromelement]]
           Some video sources can supply information about when a video frame was captured.
           This information is useful for example for AV sync and end-to-end delay measurement.
-          It MAY be set by the user agent (and be present in {{VideoFrameMetadata}}) by local capturers, or it
+          It MAY be set by the user agent (and be present in {{VideoFrameMetadata}}) by local (e.g. {{MediaDevices/getUserMedia()}}, {{MediaDevices/getDisplayMedia()}}, or {{HTMLMediaElement/captureStream()}}) capturers, or it
           MAY be supplied in {{VideoFrameMetadata}} when a VideoFrame is created.
         </p>
         <section>
           <h3>{{VideoFrameMetadata}}</h3>
-          <pre class="idl" data-cite="HR-TIME">
+          <pre class="idl">
     partial dictionary VideoFrameMetadata {
       DOMHighResTimeStamp captureTime;
     };</pre>
@@ -1176,7 +1177,7 @@ interface MediaStreamTrackVideoStats {
               <dt><dfn><code>captureTime</code></dfn> of type <span
                 class="idlMemberType">DOMHighResTimeStamp, readonly</span></dt>
               <dd>
-                <p data-cite="HR-TIME">The capture time of the frame. The timestamp is defined as {{Performance.timeOrigin}} + {{Performance.now()}} at that time.</p>
+                <p>The capture time of the frame. The timestamp is defined as {{Performance.timeOrigin}} + {{Performance.now()}} at that time.</p>
               </dd>
             </dl>
           </section>

--- a/index.html
+++ b/index.html
@@ -1238,7 +1238,7 @@ partial dictionary VideoFrameMetadata {
     <section>
       <h3>Local video capture timestamps</h3>
       <p>
-        The user agent MUST set the [= capture timestamp =] of each video frame that is sourced from
+        The user agent MUST set the [=capture timestamp=] of each video frame that is sourced from
         {{MediaDevices/getUserMedia()}} and {{MediaDevices/getDisplayMedia()}} to its best estimate of the time that
         the frame was captured, which MUST be in the past relative to the time the frame is appearing on the track.
         This value MUST be monotonically increasing.

--- a/index.html
+++ b/index.html
@@ -1161,12 +1161,14 @@ interface MediaStreamTrackVideoStats {
         the frames are sampled from the media at instants spread out over time.
       </p>
       <p>
-        Each video frame has a <dfn class="export">presentation timestamp</dfn>
-        which is relative to the first frame emitted by the {{MediaStreamTrack}}'s source, eg.
-        the timestamp of the first frame emitted by the source is 0.
-        The timestamp is present for sinks to be able to define an absolute timeline of the frames
-        relative to a clock reference. A source of frames can define how this timestamp
-        is set. A sink of frames can define how this timestamp is used.
+        Each video frame must have a <dfn class="export">presentation timestamp</dfn>
+        which is relative to a source specific origin.
+        A source of frames can define how this timestamp is set. A sink of frames
+        can define how this timestamp is used.
+      </p>
+      <p>
+        The timestamp is present for sinks to be able to define an absolute presentation timeline of the frames
+        relative to a clock reference, for example for playback.
       </p>
       <p>
         Each frame may have an absolute <dfn class="export">capture timestamp</dfn> representing
@@ -1190,10 +1192,13 @@ interface MediaStreamTrackVideoStats {
         used if set.
         The packet RTP timestamp concept is defined in [[?RFC3550]] Section 5.1.
       </p>
+      <h3>Timestamp clock relations</h3>
       <p>
+        The [=capture timestamp=] and [=receive timestamp=] are using the same clock and offset.
         The [=presentation timestamp=] and [=capture timestamp=] are using the same clock and
-        have a constant offset. The [=capture timestamp=] and [=receive timestamp=] are using the same
-        clock and offset.
+        have an offset which can be arbitrarily chosen by the user agent since it isn't
+        directly observable by script.
+        </div>
       </p>
       <h3>{{VideoFrameMetadata}}</h3>
         <pre class="idl">
@@ -1225,9 +1230,9 @@ partial dictionary VideoFrameMetadata {
       </section>
       <h3>Algorithms</h3>
       When the <dfn class="abstract-op">Initialize Video Frame Timestamps From Internal MediaStreamTrack Video Frame</dfn>
-      algorithm is invoked with |frame| as input, run the following steps.
+      algorithm is invoked with |frame| and |offset| as input, run the following steps.
       <ol class=algorithm>
-        <li>Set {{VideoFrame/timestamp}} from [=presentation timestamp=].</li>
+        <li>Set {{VideoFrame/timestamp}} from [=presentation timestamp=] minus |offset|.</li>
         <li>Set {{VideoFrameMetadata/captureTime}} from [=capture timestamp=] if set.</li>
         <li>Set {{VideoFrameMetadata/receiveTime}} from [=receive timestamp=] if set.</li>
         <li>Set {{VideoFrameMetadata/rtpTimestamp}} from [=RTP timestamp=] if set.</li>

--- a/index.html
+++ b/index.html
@@ -1162,9 +1162,9 @@ interface MediaStreamTrackVideoStats {
       </p>
       <p>
         Each video frame has a <dfn class="export">presentation timestamp</dfn>
-        which is relative to the first frame appearing on the track. The [=presentation timestamp=]
-        of the first video frame appearing on the track is 0. The timestamp
-        is present for sinks to be able to define an absolute timeline of the frames
+        which is relative to the first frame emitted by the {{MediaStreamTrack}}'s source, eg.
+        the timestamp of the first frame emitted by the source is 0.
+        The timestamp is present for sinks to be able to define an absolute timeline of the frames
         relative to a clock reference. A source of frames can define how this timestamp
         is set. A sink of frames can define how this timestamp is used.
       </p>
@@ -1189,6 +1189,11 @@ interface MediaStreamTrackVideoStats {
         timestamp is set, otherwise it is unset. A sink of frames can define how this timestamp is
         used if set.
         The packet RTP timestamp concept is defined in [[?RFC3550]] Section 5.1.
+      </p>
+      <p>
+        The [=presentation timestamp=] and [=capture timestamp=] are using the same clock and
+        have a constant offset. The [=capture timestamp=] and [=receive timestamp=] are using the same
+        clock and offset.
       </p>
       <h3>{{VideoFrameMetadata}}</h3>
         <pre class="idl">

--- a/index.html
+++ b/index.html
@@ -1162,23 +1162,29 @@ interface MediaStreamTrackVideoStats {
       </p>
       <p>
         Each video frame has a <dfn class="export">presentation timestamp</dfn>
-        which is relative to the first frame appearing on the track.
+        which is relative to the first frame appearing on the track. A sink of frames can define how
+        this timestamp is used. The timestamp is present for a sink to be able to define an absolute
+        timeline of the frames relative to a clock reference.
       </p>
       <p>
-        Each frame may have a <dfn class="export">capture timestamp</dfn> representing
-        the instant it was captured. A source of frames can define how this timestamp is set, otherwise
-        it is unset.
+        Each frame may have an absolute <dfn class="export">capture timestamp</dfn> representing
+        the instant it was captured, which is useful for example for delay measurements and synchronization.
+        A source of frames can define how this timestamp is set, otherwise it is unset. A
+        sink of frames can define how this timestamp is used if set.
       </p>
       <p>
-        Each frame may have a <dfn class="export">receive timestamp</dfn> representing
+        Each frame may have an absolute <dfn class="export">receive timestamp</dfn> representing
         the last received timestamp of packets used to produce this video frame was received in its entirety.
-        A source of frames can define how this timestamp is set, otherwise
-        it is unset.
+        The timestamp is useful for example for network jitter measurements.
+        A source of frames can define how this timestamp is set, otherwise it is unset. A sink of
+        frames can define how this timestamp is used if set.
       </p>
       <p>
-        Each frame may have a <dfn class="export">RTP timestamp</dfn> representing
-        the packet RTP timestamp used to produce this video frame. A source of frames can define how
-        this timestamp is set, otherwise it is unset.
+        Each frame may have a <dfn class="export">RTP timestamp</dfn> representing the packet RTP
+        timestamp used to produce this video frame. The timestamp is useful for example for frame
+        identification and playback quality measurements. A source of frames can define how the
+        timestamp is set, otherwise it is unset. A sink of frames can define how this timestamp is
+        used if set.
         The packet RTP timestamp concept is defined in [[?RFC3550]] Section 5.1.
       </p>
       <h3>{{VideoFrameMetadata}}</h3>
@@ -1230,10 +1236,10 @@ partial dictionary VideoFrameMetadata {
     <section>
       <h3>Local video capture timestamps</h3>
       <p>
-        The user agent MUST set the [= capture timestamp =] of each video frame
-        that is sourced from {{MediaDevices/getUserMedia()}} and
-        {{MediaDevices/getDisplayMedia()}} to its best estimate of the time that
-        the frame was captured. This value MUST be monotonically increasing.
+        The user agent MUST set the [= capture timestamp =] of each video frame that is sourced from
+        {{MediaDevices/getUserMedia()}} and {{MediaDevices/getDisplayMedia()}} to its best estimate of the time that
+        the frame was captured, which MUST be in the past relative to the time the frame is appearing on the track.
+        This value MUST be monotonically increasing.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -1155,19 +1155,19 @@ interface MediaStreamTrackVideoStats {
       </table>
     </section>
     <section class="informative">
-      <h2>Timestamp concepts</h2>
+      <h2>Video timestamp concepts</h2>
       <p>
-        Media flowing inside media stream tracks comprise of a sequence of media frames, where
+        Video media flowing inside media stream tracks comprise of a sequence of video frames, where
         the frames are sampled from the media at instants spread out over time.
+      </p>
+      <p>
+        Each video frame has a <dfn class="export">presentation timestamp</dfn>
+        which is relative to the first frame appearing on the track.
       </p>
       <p>
         Each frame may have a <dfn class="export">capture timestamp</dfn> representing
         the instant it was captured. A source of frames can define how this timestamp is set, otherwise
         it is unset.
-      </p>
-      <p>
-        Each video frame has a <dfn class="export">presentation timestamp</dfn>
-        which is relative to the first frame appearing on the track.
       </p>
       <p>
         Each frame may have a <dfn class="export">receive timestamp</dfn> representing
@@ -1193,30 +1193,39 @@ partial dictionary VideoFrameMetadata {
         <dl class="dictionary-members" data-link-for="VideoFrameMetadata" data-dfn-for="VideoFrameMetadata">
           <dt><dfn><code>captureTime</code></dfn> of type <span class="idlMemberType">DOMHighResTimeStamp</span></dt>
           <dd>
-            <p>
-              The capture timestamp of the frame relative to {{Performance}}.{{Performance/timeOrigin}}.
-              MUST be set to the [=capture timestamp=] of the source {{MediaStreamTrack}} video frame if set.
-              It is not [=map/exist|present=] if [=capture timestamp=] is unset.
+            <p>The capture timestamp of the frame relative to {{Performance}}.{{Performance/timeOrigin}}. It corresponds to
+              the [=capture timestamp=] of {{MediaStreamTrack}} video frames.
             </p>
           </dd>
           <dt><dfn><code>receiveTime</code></dfn> of type <span class="idlMemberType">DOMHighResTimeStamp</span></dt>
           <dd>
-            <p>
-              The receive time of the corresponding encoded frame relative to {{Performance}}.{{Performance/timeOrigin}}.
-              MUST be set to the [=receive timestamp=] of the source {{MediaStreamTrack}} video frame if set.
-              It is not [=map/exist|present=] if [=receive timestamp=] is unset.
-            </p>
+            <p>The receive time of the corresponding encoded frame relative to {{Performance}}.{{Performance/timeOrigin}}.
+              It corresponds to the [=receive timestamp=] of {{MediaStreamTrack}} video frames.</p>
           </dd>
           <dt><dfn><code>rtpTimestamp</code></dfn> of type <span class="idlMemberType">unsigned long</span></dt>
           <dd>
-            <p>
-              The RTP timestamp of the corresponding encoded frame.
-              MUST be set to the [=RTP timestamp=] of the source {{MediaStreamTrack}} video frames if set.
-              It is not [=map/exist|present=] if [=receive timestamp=] is unset.
-            </p>
+            <p>The RTP timestamp of the corresponding encoded frame.  It corresponds to [=RTP timestamp=] of
+            {{MediaStreamTrack}} video frames.</p>
           </dd>
         </dl>
       </section>
+      <h3>Algorithms</h3>
+      The <dfn for=VideoFrame class="export">Initialize Video Frame Timestamps From Internal MediaStreamTrack Video Frame</dfn>
+      algorithm runs with |frame| as input.
+      <ol>
+        <li>Set {{VideoFrame/timestamp}} from [=presentation timestamp=].</li>
+        <li>Set {{VideoFrameMetadata/captureTime}} from [=capture timestamp=] if set.</li>
+        <li>Set {{VideoFrameMetadata/receiveTime}} from [=receive timestamp=] if set.</li>
+        <li>Set {{VideoFrameMetadata/rtpTimestamp}} from [=RTP timestamp=] if set.</li>
+      </ol>
+      The <dfn for=VideoFrame class="export">Copy Video Frame Timestamps To Internal MediaStreamTrack Video Frame</dfn>
+      algorithm runs with |frame| as input.
+      <ol>
+        <li>Set [=presentation timestamp=] from {{VideoFrame/timestamp}}.</li>
+        <li>Set [=capture timestamp=] from {{VideoFrameMetadata/captureTime}} if [=map/exist|present=].</li>
+        <li>Set [=receive timestamp=] from {{VideoFrameMetadata/receiveTime}} if [=map/exist|present=].</li>
+        <li>Set [=RTP timestamp=] from {{VideoFrameMetadata/rtpTimestamp}} if [=map/exist|present=].</li>
+      </ol>
     </section>
     <section>
       <h3>Local video capture timestamps</h3>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
   var respecConfig = {
     group: "webrtc",
-    xref: ["geometry-1", "html", "infra", "permissions", "dom", "hr-time", "image-capture", "mediacapture-streams", "screen-capture", "webaudio", "webcodecs", "webidl"],
+    xref: ["geometry-1", "html", "infra", "permissions", "dom", "hr-time", "image-capture", "mediacapture-fromelement", "mediacapture-streams", "screen-capture", "webaudio", "webcodecs", "webidl"],
     edDraftURI: "https://w3c.github.io/mediacapture-extensions/",
     editors:  [
       {name: "Jan-Ivar Bruaroey", company: "Mozilla Corporation", w3cid: 79152},
@@ -1158,12 +1158,13 @@ interface MediaStreamTrackVideoStats {
     <section>
       <h2>Capture timestamps</h2>
       <div>
-        <p>
-          [[mediacapture-fromelement]]
           Some video sources can supply information about when a video frame was captured.
           This information is useful for example for AV sync and end-to-end delay measurement.
-          It MAY be set by the user agent (and be present in {{VideoFrameMetadata}}) by local (e.g. {{MediaDevices/getUserMedia()}}, {{MediaDevices/getDisplayMedia()}}, or {{HTMLMediaElement/captureStream()}}) capturers, or it
-          MAY be supplied in {{VideoFrameMetadata}} when a VideoFrame is created.
+        </p>
+        <p>
+          {{VideoFrameMetadata}}.{{VideoFrameMetadata/captureTime}} MUST be set by the user
+          agent in video frames sourced from {{MediaDevices/getUserMedia()}},
+          {{MediaDevices/getDisplayMedia()}}, and {{HTMLMediaElement/captureStream()}}.
         </p>
         <section>
           <h3>{{VideoFrameMetadata}}</h3>
@@ -1177,7 +1178,11 @@ interface MediaStreamTrackVideoStats {
               <dt><dfn><code>captureTime</code></dfn> of type <span
                 class="idlMemberType">DOMHighResTimeStamp, readonly</span></dt>
               <dd>
-                <p>The capture time of the frame. The timestamp is defined as {{Performance.timeOrigin}} + {{Performance.now()}} at that time.</p>
+                <p>
+                  The capture time of the frame, defined as {{Performance.timeOrigin}} + {{Performance.now()}}.
+                  This is the user agent's best estimate of the instant the frame content was captured or
+                  generated.
+                </p>
               </dd>
             </dl>
           </section>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
   var respecConfig = {
     group: "webrtc",
-    xref: ["geometry-1", "html", "infra", "permissions", "dom", "hr-time", "image-capture", "mediacapture-fromelement", "mediacapture-streams", "screen-capture", "webaudio", "webcodecs", "webidl"],
+    xref: ["geometry-1", "html", "infra", "permissions", "dom", "hr-time", "image-capture", "mediacapture-streams", "screen-capture", "webaudio", "webcodecs", "webidl"],
     edDraftURI: "https://w3c.github.io/mediacapture-extensions/",
     editors:  [
       {name: "Jan-Ivar Bruaroey", company: "Mozilla Corporation", w3cid: 79152},
@@ -59,8 +59,7 @@
       <a data-cite="permissions">prompt the user to choose</a> are defined in
       [[!permissions]].</p>
       <p>
-        {{Performance.timeOrigin}} and {{Performance.now()}} are defined in
-        [[!hr-time]].
+        {{Performance.now()}} is defined in [[!hr-time]].
       </p>
   </section>
   <section id="conformance">
@@ -1155,41 +1154,81 @@ interface MediaStreamTrackVideoStats {
         </tbody>
       </table>
     </section>
-    <section>
-      <h2>Capture timestamps</h2>
-      <div>
-          Some video sources can supply information about when a video frame was captured.
-          This information is useful for example for AV sync and end-to-end delay measurement.
-        </p>
-        <p>
-          {{VideoFrameMetadata}}.{{VideoFrameMetadata/captureTime}} MUST be set by the user
-          agent in video frames sourced from {{MediaDevices/getUserMedia()}},
-          {{MediaDevices/getDisplayMedia()}}, and {{HTMLMediaElement/captureStream()}}.
-        </p>
-        <section>
-          <h3>{{VideoFrameMetadata}}</h3>
-          <pre class="idl">
-    partial dictionary VideoFrameMetadata {
-      DOMHighResTimeStamp captureTime;
-    };</pre>
-          <section class="notoc">
-            <h4>Members</h4>
-            <dl class="dictionary-members" data-link-for="VideoFrameMetadata" data-dfn-for="VideoFrameMetadata">
-              <dt><dfn><code>captureTime</code></dfn> of type <span
-                class="idlMemberType">DOMHighResTimeStamp, readonly</span></dt>
-              <dd>
-                <p>
-                  The capture time of the frame, defined as {{Performance.timeOrigin}} + {{Performance.now()}}.
-                  This is the user agent's best estimate of the instant the frame content was captured or
-                  generated.
-                </p>
-              </dd>
-            </dl>
-          </section>
-        </section>
-      </div>
+    <section class="informative">
+      <h2>Timestamp concepts</h2>
+      <p>
+        Media flowing inside media stream tracks comprise of a sequence of media frames, where
+        the frames are sampled from the media at instants spread out over time.
+      </p>
+      <p>
+        Each frame may have a <dfn class="export">capture timestamp</dfn> representing
+        the instant it was captured. A source of frames can define how this timestamp is set, otherwise
+        it is unset.
+      </p>
+      <p>
+        Each video frame has a <dfn class="export">presentation timestamp</dfn>
+        which is relative to the first frame appearing on the track.
+      </p>
+      <p>
+        Each frame may have a <dfn class="export">receive timestamp</dfn> representing
+        the last received timestamp of packets used to produce this video frame was received in its entirety.
+        A source of frames can define how this timestamp is set, otherwise
+        it is unset.
+      </p>
+      <p>
+        Each frame may have a <dfn class="export">RTP timestamp</dfn> representing
+        the packet RTP timestamp used to produce this video frame. A source of frames can define how
+        this timestamp is set, otherwise it is unset.
+        The packet RTP timestamp concept is defined in [[?RFC3550]] Section 5.1.
+      </p>
+      <h3>{{VideoFrameMetadata}}</h3>
+        <pre class="idl">
+partial dictionary VideoFrameMetadata {
+  DOMHighResTimeStamp captureTime;
+  DOMHighResTimeStamp receiveTime;
+  unsigned long rtpTimestamp;
+};</pre>
+      <section class="notoc">
+        <h5>Members</h5>
+        <dl class="dictionary-members" data-link-for="VideoFrameMetadata" data-dfn-for="VideoFrameMetadata">
+          <dt><dfn><code>captureTime</code></dfn> of type <span class="idlMemberType">DOMHighResTimeStamp</span></dt>
+          <dd>
+            <p>
+              The capture timestamp of the frame relative to {{Performance}}.{{Performance/timeOrigin}}.
+              MUST be set to the [=capture timestamp=] of the source {{MediaStreamTrack}} video frame if set.
+              It is not [=map/exist|present=] if [=capture timestamp=] is unset.
+            </p>
+          </dd>
+          <dt><dfn><code>receiveTime</code></dfn> of type <span class="idlMemberType">DOMHighResTimeStamp</span></dt>
+          <dd>
+            <p>
+              The receive time of the corresponding encoded frame relative to {{Performance}}.{{Performance/timeOrigin}}.
+              MUST be set to the [=receive timestamp=] of the source {{MediaStreamTrack}} video frame if set.
+              It is not [=map/exist|present=] if [=receive timestamp=] is unset.
+            </p>
+          </dd>
+          <dt><dfn><code>rtpTimestamp</code></dfn> of type <span class="idlMemberType">unsigned long</span></dt>
+          <dd>
+            <p>
+              The RTP timestamp of the corresponding encoded frame.
+              MUST be set to the [=RTP timestamp=] of the source {{MediaStreamTrack}} video frames if set.
+              It is not [=map/exist|present=] if [=receive timestamp=] is unset.
+            </p>
+          </dd>
+        </dl>
+      </section>
     </section>
-  <section>
+    <section>
+      <h3>Local video capture timestamps</h3>
+      <p>
+        The user agent MUST set the [= capture timestamp =] of each video frame
+        that is sourced from {{MediaDevices/getUserMedia()}} and
+        {{MediaDevices/getDisplayMedia()}} to its best estimate of the time that
+        the frame was captured. This value MUST be monotonically increasing.
+      </p>
+    </section>
+
+    <section>
     <h2>Exposing MediaStreamTrack source heuristic reactions support</h2>
     <div>
       <p>Some platforms or User Agents may provide built-in support for video effects triggered by user motion heuristics, in particular for camera video streams.

--- a/index.html
+++ b/index.html
@@ -58,6 +58,10 @@
       <p>The terms [=permission state=], [=request permission to use=], and
       <a data-cite="permissions">prompt the user to choose</a> are defined in
       [[!permissions]].</p>
+      <p>
+        {{Performance.timeOrigin}} and {{Performance.now()}} are defined in
+        [[!hr-time]].
+      </p>
   </section>
   <section id="conformance">
   </section>
@@ -1150,6 +1154,34 @@ interface MediaStreamTrackVideoStats {
           </tr>
         </tbody>
       </table>
+    </section>
+    <section>
+      <h2>Capture timestamps</h2>
+      <div>
+        <p>
+          Some video sources can supply information about when a video frame was captured.
+          This information is useful for example for AV sync and end-to-end delay measurement.
+          It MAY be set by the user agent (and be present in {{VideoFrameMetadata}}) by local capturers, or it
+          MAY be supplied in {{VideoFrameMetadata}} when a VideoFrame is created.
+        </p>
+        <section>
+          <h3>{{VideoFrameMetadata}}</h3>
+          <pre class="idl" data-cite="HR-TIME">
+    partial dictionary VideoFrameMetadata {
+      DOMHighResTimeStamp captureTime;
+    };</pre>
+          <section class="notoc">
+            <h4>Members</h4>
+            <dl class="dictionary-members" data-link-for="VideoFrameMetadata" data-dfn-for="VideoFrameMetadata">
+              <dt><dfn><code>captureTime</code></dfn> of type <span
+                class="idlMemberType">DOMHighResTimeStamp, readonly</span></dt>
+              <dd>
+                <p data-cite="HR-TIME">The capture time of the frame. The timestamp is defined as {{Performance.timeOrigin}} + {{Performance.now()}} at that time.</p>
+              </dd>
+            </dl>
+          </section>
+        </section>
+      </div>
     </section>
   <section>
     <h2>Exposing MediaStreamTrack source heuristic reactions support</h2>

--- a/index.html
+++ b/index.html
@@ -1253,6 +1253,10 @@ partial dictionary VideoFrameMetadata {
         the frame was captured.
         This value MUST be monotonically increasing.
       </p>
+      <div class="note">
+        Local capture tracks have a fixed offset between [=presentation timestamp=] and [=capture timestamp=]. The
+        user agent may let this be zero with the result that [=presentation timestamp=] is the same as [=capture timestamp=].
+      </div>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -1212,7 +1212,7 @@ partial dictionary VideoFrameMetadata {
           </dd>
           <dt><dfn><code>rtpTimestamp</code></dfn> of type <span class="idlMemberType">unsigned long</span></dt>
           <dd>
-            <p>The RTP timestamp of the corresponding encoded frame.  It corresponds to [=RTP timestamp=] of
+            <p>The RTP timestamp of the corresponding encoded frame. It corresponds to [=RTP timestamp=] of
             {{MediaStreamTrack}} video frames.</p>
           </dd>
         </dl>

--- a/index.html
+++ b/index.html
@@ -1162,13 +1162,15 @@ interface MediaStreamTrackVideoStats {
       </p>
       <p>
         Each video frame has a <dfn class="export">presentation timestamp</dfn>
-        which is relative to the first frame appearing on the track. A sink of frames can define how
-        this timestamp is used. The timestamp is present for a sink to be able to define an absolute
-        timeline of the frames relative to a clock reference.
+        which is relative to the first frame appearing on the track. The timestamp
+        is present for sinks to be able to define an absolute timeline of the frames
+        relative to a clock reference. A source of frames can define how this timestamp
+        is set. A sink of frames can define how this timestamp is used.
       </p>
       <p>
         Each frame may have an absolute <dfn class="export">capture timestamp</dfn> representing
-        the instant it was captured, which is useful for example for delay measurements and synchronization.
+        the instant the frame capture process began, which is useful for example for
+        delay measurements and synchronization.
         A source of frames can define how this timestamp is set, otherwise it is unset. A
         sink of frames can define how this timestamp is used if set.
       </p>
@@ -1216,7 +1218,7 @@ partial dictionary VideoFrameMetadata {
         </dl>
       </section>
       <h3>Algorithms</h3>
-      The <dfn for=VideoFrame class="export">Initialize Video Frame Timestamps From Internal MediaStreamTrack Video Frame</dfn>
+      The <dfn class="export">Initialize Video Frame Timestamps From Internal MediaStreamTrack Video Frame</dfn>
       algorithm runs with |frame| as input.
       <ol>
         <li>Set {{VideoFrame/timestamp}} from [=presentation timestamp=].</li>
@@ -1224,7 +1226,7 @@ partial dictionary VideoFrameMetadata {
         <li>Set {{VideoFrameMetadata/receiveTime}} from [=receive timestamp=] if set.</li>
         <li>Set {{VideoFrameMetadata/rtpTimestamp}} from [=RTP timestamp=] if set.</li>
       </ol>
-      The <dfn for=VideoFrame class="export">Copy Video Frame Timestamps To Internal MediaStreamTrack Video Frame</dfn>
+      The <dfn class="export">Copy Video Frame Timestamps To Internal MediaStreamTrack Video Frame</dfn>
       algorithm runs with |frame| as input.
       <ol>
         <li>Set [=presentation timestamp=] from {{VideoFrame/timestamp}}.</li>

--- a/index.html
+++ b/index.html
@@ -1198,7 +1198,6 @@ interface MediaStreamTrackVideoStats {
         The [=presentation timestamp=] and [=capture timestamp=] are using the same clock and
         have an offset which can be arbitrarily chosen by the user agent since it isn't
         directly observable by script.
-        </div>
       </p>
       <h3>{{VideoFrameMetadata}}</h3>
         <pre class="idl">

--- a/index.html
+++ b/index.html
@@ -1228,7 +1228,7 @@ partial dictionary VideoFrameMetadata {
       </ol>
       The <dfn class="abstract-op">Copy Video Frame Timestamps To Internal MediaStreamTrack Video Frame</dfn>
       algorithm runs with |frame| as input.
-      <ol>
+      <ol class=algorithm>
         <li>Set [=presentation timestamp=] from {{VideoFrame/timestamp}}.</li>
         <li>Set [=capture timestamp=] from {{VideoFrameMetadata/captureTime}} if [=map/exist|present=].</li>
         <li>Set [=receive timestamp=] from {{VideoFrameMetadata/receiveTime}} if [=map/exist|present=].</li>

--- a/index.html
+++ b/index.html
@@ -1226,7 +1226,7 @@ partial dictionary VideoFrameMetadata {
         <li>Set {{VideoFrameMetadata/receiveTime}} from [=receive timestamp=] if set.</li>
         <li>Set {{VideoFrameMetadata/rtpTimestamp}} from [=RTP timestamp=] if set.</li>
       </ol>
-      The <dfn class="export">Copy Video Frame Timestamps To Internal MediaStreamTrack Video Frame</dfn>
+      The <dfn class="abstract-op">Copy Video Frame Timestamps To Internal MediaStreamTrack Video Frame</dfn>
       algorithm runs with |frame| as input.
       <ol>
         <li>Set [=presentation timestamp=] from {{VideoFrame/timestamp}}.</li>


### PR DESCRIPTION
Partly addresses https://github.com/w3c/webcodecs/pull/813#pullrequestreview-2169568794.

Defines capturetime in mediacapture-extensions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/handellm/mediacapture-extensions/pull/156.html" title="Last updated on Oct 11, 2024, 2:04 PM UTC (fcafe1c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/156/14ff6a3...handellm:fcafe1c.html" title="Last updated on Oct 11, 2024, 2:04 PM UTC (fcafe1c)">Diff</a>