### PR TITLE
Remove empty <section> to fix syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -1905,8 +1905,6 @@ partial dictionary VideoFrameMetadata {
       <h3>{{BackgroundBlur}}</h3>
       <pre class="idl">
 dictionary BackgroundBlur: MediaEffectInfo {};</pre>
-      <section class="notoc">
-      </section>
     </section>
     <section>
       <h3>{{MediaEffectInfo}}</h3>


### PR DESCRIPTION
This fixes ReSpec errors.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eehakkin/intel-w3c-mediacapture-extensions/pull/163.html" title="Last updated on May 14, 2025, 2:01 PM UTC (89bf1ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/163/234f052...eehakkin:89bf1ee.html" title="Last updated on May 14, 2025, 2:01 PM UTC (89bf1ee)">Diff</a>