### PR TITLE
Avoid non-consensus WebIDL

### DIFF
--- a/index.html
+++ b/index.html
@@ -512,10 +512,6 @@ partial interface MediaStreamTrack {
       <div>
         <pre class="idl" data-cite="HR-TIME">[Exposed=(Window,DedicatedWorker)]
 interface MediaStreamTrackAudioStats {
-  readonly attribute unsigned long long deliveredFrames;
-  readonly attribute DOMHighResTimeStamp deliveredFramesDuration;
-  readonly attribute unsigned long long totalFrames;
-  readonly attribute DOMHighResTimeStamp totalFramesDuration;
   readonly attribute DOMHighResTimeStamp latency;
   readonly attribute DOMHighResTimeStamp averageLatency;
   readonly attribute DOMHighResTimeStamp minimumLatency;
@@ -526,10 +522,14 @@ interface MediaStreamTrackAudioStats {
         </pre>
         <div class="note">
           <p>The following metrics lack Working Group consensus:
-          {{MediaStreamTrackAudioStats/deliveredFrames}},
-          {{MediaStreamTrackAudioStats/deliveredFramesDuration}},
-          {{MediaStreamTrackAudioStats/totalFrames}} and
-          {{MediaStreamTrackAudioStats/totalFramesDuration}}. See <a
+        <pre class="idl" data-cite="HR-TIME">[Exposed=(Window,DedicatedWorker)]
+partial interface MediaStreamTrackAudioStats {
+  readonly attribute unsigned long long deliveredFrames;
+  readonly attribute DOMHighResTimeStamp deliveredFramesDuration;
+  readonly attribute unsigned long long totalFrames;
+  readonly attribute DOMHighResTimeStamp totalFramesDuration;
+};
+        </pre>See <a
           href="https://github.com/w3c/mediacapture-extensions/issues/129">Issue
           #129</a>.</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -522,8 +522,7 @@ interface MediaStreamTrackAudioStats {
         </pre>
         <div class="note">
           <p>The following metrics lack Working Group consensus:
-        <pre class="idl" data-cite="HR-TIME">[Exposed=(Window,DedicatedWorker)]
-partial interface MediaStreamTrackAudioStats {
+        <pre class="idl" data-cite="HR-TIME">partial interface MediaStreamTrackAudioStats {
   readonly attribute unsigned long long deliveredFrames;
   readonly attribute DOMHighResTimeStamp deliveredFramesDuration;
   readonly attribute unsigned long long totalFrames;


### PR DESCRIPTION
Related to #129. Makes it clearer which WebIDL members have consensus.

Hopefully, WebIDL in a note is not picked up by tools. But if that doesn't work we can follow what we did for [ConstrainablePattern](https://w3c.github.io/mediacapture-main/#dfn-settings-0).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-extensions/pull/166.html" title="Last updated on Oct 16, 2025, 6:19 PM UTC (35c1f23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/166/aad3334...jan-ivar:35c1f23.html" title="Last updated on Oct 16, 2025, 6:19 PM UTC (35c1f23)">Diff</a>