### PR TITLE
 Add Media Capture Elements (<usermedia>, <camera>, <microphone>) and Explainer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2099,12 +2099,10 @@ onmessage = async ({data: {track}}) => {
         The &lt;<dfn data-dfn-type="element">camera</dfn>&gt; HTML element is an
         [[HTML]] element that can mediate access to a camera's video
         {{MediaStreamTrack}}.
-        The [^camera^] element is {{SecureContext}} restricted. Outside
-        of a [=secure context=] it uses the default [=element interface=].
-        In a [=secure context=] it uses the following [=element interface=]:
+        The [^camera^] element uses the following [=element interface=]:
       </p>
       <pre class=idl>
-      [Exposed=Window, SecureContext]
+      [Exposed=Window]
       interface HTMLCameraElement : HTMLElement {
         [HTMLConstructor] constructor();
 
@@ -2183,6 +2181,13 @@ onmessage = async ({data: {track}}) => {
         <dd>&mdash; [=event handler IDL attributes=]</dd>
       </dl>
 
+      <p>The [^camera^] element, like the underlying
+        {{MediaDevices}} interface and {{MediaDevices/getUserMedia()}} method,
+        only work in a [=/secure context=]. In a [=/non-secure context=],
+        [^camera^] displays its
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#fallback-content">fallback content</a>.
+      </p>
+
       <p>The [^camera^] element's presentation is left to the [=user
         agent=]. It's expected that the presentation is chiefly that of a button,
         with text and/or an icon to indicate this is managing camera access.
@@ -2230,9 +2235,7 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>
-            Set [=this=].{{HTMLCameraElement/[[constraints]]}} to |constraints|
-            to the result of [=HTMLCameraElement/constraint filter=] with
-            |constraints|.
+            Set [=this=].{{HTMLCameraElement/[[constraints]]}} to |constraints|.
           </li>
         </ol>
 
@@ -2241,6 +2244,11 @@ onmessage = async ({data: {track}}) => {
           given |event| is:
         </p>
         <ol class=algorithm>
+          <li>If [=this=]'s [=node navigable=] is a [=/non-secure context=],
+            then return.</li>
+          <li>If [=this=]'s [=node navigable=]'s [=navigable/active window=]
+            does not have [=/transient activation|transient user activation=],
+            then return.</li>
           <li>If |event| is not [=AllUserMediaElements/trusted=], then
             [=AllUserMediaElements/queue an event=] named `error` on [=this=],
             using an "{{InvalidStateError}}" {{DOMException}} and abort these
@@ -2265,9 +2273,12 @@ onmessage = async ({data: {track}}) => {
         steps for a given |element| are:</p>
         <ol class=algorithm>
           <li>[=Assert=]: [=this=].{{HTMLCameraElement/[[track]]}} is null.</li>
+          <li>Set |constraints| to the result of
+            [=HTMLCameraElement/constraint filter=] with
+            {{HTMLCameraElement/[[constraints]]}}.
           <li>
             Let |mediaPromise| be the result of calling
-            [=this=].{{MediaDevices/getUserMedia()}} with {{HTMLCameraElement/[[constraints]]}}
+            [=this=].{{MediaDevices/getUserMedia()}} with |constraints|
             as its first argument.
 
             <div class=note>
@@ -2343,12 +2354,10 @@ onmessage = async ({data: {track}}) => {
         The &lt;<dfn data-dfn-type="element">microphone</dfn>&gt; HTML element
         is an [[HTML]] element that can mediate access to a microphone's audio
         {{MediaStreamTrack}}.
-        The [^microphone^] element is {{SecureContext}} restricted. Outside
-        of a [=secure context=] it uses the default [=element interface=].
-        In a [=secure context=] it uses the following [=element interface=]:
+        The [^microphone^] element uses the following [=element interface=]:
       </p>
       <pre class=idl>
-      [Exposed=Window, SecureContext]
+      [Exposed=Window]
       interface HTMLMicrophoneElement : HTMLElement {
         [HTMLConstructor] constructor();
 
@@ -2435,6 +2444,13 @@ onmessage = async ({data: {track}}) => {
         is live (or not), or that the microphone might be open or muted.
       </p>
 
+      <p>The [^microphone^] element, like the underlying
+        {{MediaDevices}} interface and {{MediaDevices/getUserMedia()}} method,
+        only work in a [=/secure context=]. In a [=/non-secure context=],
+        [^microphone^] displays its
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#fallback-content">fallback content</a>.
+      </p>
+
       <p>The [=user agent=] is expected to monitor the state of the underlying
         track and to continuously reflect this state in the user interface of
         the [^microphone^] element. For example,
@@ -2474,8 +2490,7 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>
-            Set [=this=].{{HTMLMicrophoneElement/[[constraints]]}} to the result
-            of [=HTMLMicrophoneElement/constraint filter=] with |constraints|.
+            Set [=this=].{{HTMLMicrophoneElement/[[constraints]]}} to |constraints|.
           </li>
         </ol>
 
@@ -2484,6 +2499,11 @@ onmessage = async ({data: {track}}) => {
           [=EventTarget/activation behavior=] given |event| is:
         </p>
         <ol class=algorithm>
+          <li>If [=this=]'s [=node navigable=] is a [=/non-secure context=],
+            then return.</li>
+          <li>If [=this=]'s [=node navigable=]'s [=navigable/active window=]
+            does not have [=/transient activation|transient user activation=],
+            then return.</li>
           <li>If |event| is not [=AllUserMediaElements/trusted=], then
             [=AllUserMediaElements/queue an event=] named `error`, using an
             "{{InvalidStateError}}" {{DOMException}}.
@@ -2508,10 +2528,13 @@ onmessage = async ({data: {track}}) => {
 
         <ol class=algorithm>
           <li>[=Assert=]: [=this=].{{HTMLMicrophoneElement/[[track]]}} is null.</li>
+          <li>Set |constraints| to the result of
+            [=HTMLMicrophoneElement/constraint filter=] with
+            {{HTMLMicrophoneElement/[[constraints]]}}.</li>
           <li>
             Let |mediaPromise| be the result of calling
-            [=this=].{{MediaDevices/getUserMedia()}} with
-            {{HTMLMicrophoneElement/[[constraints]]}} as its first argument.
+            [=this=].{{MediaDevices/getUserMedia()}} with |constraints|
+            as its first argument.
             <div class=note>
               The call to the {{MediaDevices/getUserMedia()}} method should
               be replaced with a non-IDL entry point or algorithm.
@@ -2584,18 +2607,15 @@ onmessage = async ({data: {track}}) => {
         The &lt;<dfn data-dfn-type="element">usermedia</dfn>&gt; HTML element
         is an [[HTML]] element that can mediate access to a {{MediaStream}}
         consisting of a microphone and a camera track.
-        The [^usermedia^] element is {{SecureContext}} restricted. Outside
-        of a [=secure context=] it uses the default [=element interface=].
-        In a [=secure context=] it uses the following [=element interface=]:
+        The [^usermedia^] element uses the following [=element interface=]:
       </p>
       <pre class=idl>
-      [SecureContext]
       dictionary HTMLMediaStreamConstraints {
         MediaTrackConstraintSet video;
         MediaTrackConstraintSet audio;
       };
 
-      [Exposed=Window, SecureContext]
+      [Exposed=Window]
       interface HTMLUserMediaElement : HTMLElement {
         [HTMLConstructor] constructor();
 
@@ -2682,6 +2702,14 @@ onmessage = async ({data: {track}}) => {
         (or not), or that the camera and microphone might be active or muted.
       </p>
 
+      <p>
+        The [^usermedia^] element, like the underlying
+        {{MediaDevices}} interface and {{MediaDevices/getUserMedia()}} method,
+        only work in a [=/secure context=]. In a [=/non-secure context=],
+        [^usermedia^] displays its
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#fallback-content">fallback content</a>.
+      </p>
+
       <p>The [=user agent=] is expected to monitor the state of the underlying
         track and to continuously reflect this state in the user interface of
         the [^usermedia^] element. For example,
@@ -2722,8 +2750,7 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>
-            Set [=this=].{{HTMLUserMediaElement/[[constraints]]}} to the result of
-            [=HTMLUserMediaElement/constraint filter=] with |constraints|.
+            Set [=this=].{{HTMLUserMediaElement/[[constraints]]}} to |constraints|.
           </li>
         </ol>
 
@@ -2732,6 +2759,11 @@ onmessage = async ({data: {track}}) => {
           given |event|, is:
         </p>
         <ol class=algorithm>
+          <li>If [=this=]'s [=node navigable=] is a [=/non-secure context=],
+            then return.</li>
+          <li>If [=this=]'s [=node navigable=]'s [=navigable/active window=]
+            does not have [=/transient activation|transient user activation=],
+            then return.</li>
           <li>If |event| is not [=AllUserMediaElements/trusted=], then
             [=AllUserMediaElements/queue an event=] named `error`, using an
             "{{InvalidStateError}}" {{DOMException}}.
@@ -2756,9 +2788,12 @@ onmessage = async ({data: {track}}) => {
         <ol class=algorithm>
           <li>[=Assert=]: [=this=].{{HTMLUserMediaElement/[[stream]]}} is
             null.</li>
+          <li>Let |constraints| be the result of calling
+            [=HTMLUserMediaElement/constraint filter=] with
+            {{HTMLUserMediaElement/[[constraints]]}}.</li>
           <li>Let |mediaPromise| be the result of calling
             [=this=].{{MediaDevices/getUserMedia()}} with
-            {{HTMLUserMediaElement/[[constraints]]}} as its first argument.
+            |constraints| as its first argument.
             <div class=note>
               The call to the {{MediaDevices/getUserMedia()}} method should
               be replaced with a non-IDL entry point or algorithm.

--- a/index.html
+++ b/index.html
@@ -2191,6 +2191,17 @@ onmessage = async ({data: {track}}) => {
         (or not), or that the camera might be open or muted.
       </p>
 
+      <p>The [=user agent=] is expected to monitor the state of the underlying
+        track and to continuously reflect this state in the user interface of
+        the [^camera^] element. For example,
+        whether a track has been requested but is waiting for user action;
+        whether it is active or has been stopped (by any means, including
+        direct calls to {{MediaStreamTrack/stop()}}), or whether a track is
+        muted. This specification does not explicitly call out when such state
+        changes might occur, or demand a specific set of states to display to
+        the user.
+      </p>
+
       <section>
         <h4>Algorithms</h4>
 
@@ -2288,9 +2299,7 @@ onmessage = async ({data: {track}}) => {
                   <li>[=Assert=]: |tracks|'s [=list/size=] is 1.</li>
                   <li>Set
                     {{HTMLCameraElement/[[track]]}} to |tracks|[0].</li>
-                  <li>Run the [=HTMLCameraElement/track monitor=] steps on [=this=].</li>
                   <li>[=AllUserMediaElements/Queue an event=] named `track` on [=this=].</li>
-
                 </ol>
               </li>
               <li>Otherwise:
@@ -2310,34 +2319,6 @@ onmessage = async ({data: {track}}) => {
                 </ol>
               </li>
             </ol>
-          </li>
-        </ol>
-
-        <p>The <dfn data-dfn-for="HTMLCameraElement">track monitor</dfn> steps are:</p>
-        <ol class=algorithm>
-          <li>[=Assert=]: {{HTMLCameraElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
-          <li>
-            The user agent monitors the {{HTMLCameraElement/[[track]]}}'s
-            {{MediaStreamTrack/readyState}} (including for
-            terminations triggered by {{MediaStreamTrack/stop()}}), and its
-            {{MediaStreamTrack/muted}} state.
-            <div class=note>This monitoring is mostly provided by existing
-              event handlers on {{MediaStreamTrack}}, except that the
-              {{MediaStreamTrack/stop()}} method
-              <a href="https://w3c.github.io/mediacapture-main/#ends-nostop">will not dispatch any events</a>.
-              However, a track ending due to {{MediaStreamTrack/stop()}}
-              should still reflect the {{HTMLCameraElement}} state.
-            </div>
-          </li>
-          <li>
-            When the state of the monitored {{HTMLCameraElement/[[track]]}}
-            changes, the user agent updates the |element|'s internal UI to
-            reflect the active, muted, or ended state of the track.
-          </li>
-          <li>
-            If {{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/readyState}}
-            becomes `"ended"`, the user agent updates its presentation
-            appropriately.
           </li>
         </ol>
 
@@ -2454,6 +2435,17 @@ onmessage = async ({data: {track}}) => {
         is live (or not), or that the microphone might be open or muted.
       </p>
 
+      <p>The [=user agent=] is expected to monitor the state of the underlying
+        track and to continuously reflect this state in the user interface of
+        the [^microphone^] element. For example,
+        whether a track has been requested but is waiting for user action;
+        whether it is active or has been stopped (by any means, including
+        direct calls to {{MediaStreamTrack/stop()}}), or whether a track is
+        muted. This specification does not explicitly call out when such state
+        changes might occur, or demand a specific set of states to display to
+        the user.
+      </p>
+
       <section>
         <h4>Algorithms</h4>
 
@@ -2549,9 +2541,7 @@ onmessage = async ({data: {track}}) => {
                   <li>[=Assert=]: |tracks|'s [=list/size=] is 1.</li>
                   <li>Set
                     {{HTMLMicrophoneElement/[[track]]}} to |tracks|[0].</li>
-                  <li>Run the [=HTMLMicrophoneElement/track monitor=] steps on [=this=].</li>
                   <li>[=AllUserMediaElements/Queue an event=] named `track` on [=this=].</li>
-
                 </ol>
               </li>
               <li>Otherwise:
@@ -2571,35 +2561,6 @@ onmessage = async ({data: {track}}) => {
                 </ol>
               </li>
             </ol>
-          </li>
-        </ol>
-
-        <p>The <dfn data-dfn-for="HTMLMicrophoneElement">track monitor</dfn> steps are:</p>
-        <ol class=algorithm>
-          <li>[=Assert=]: {{HTMLMicrophoneElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
-          <li>
-            The user agent monitors the {{HTMLMicrophoneElement/[[track]]}}'s
-            {{MediaStreamTrack/readyState}} (including for
-            terminations triggered by {{MediaStreamTrack/stop()}}), its
-            {{MediaStreamTrack/enabled}} state, and its
-            {{MediaStreamTrack/muted}} state.
-            <div class=note>This monitoring is mostly provided by existing
-              event handlers on {{MediaStreamTrack}}, except that the
-              {{MediaStreamTrack/stop()}} method
-              <a href="https://w3c.github.io/mediacapture-main/#ends-nostop">will not dispatch any events</a>.
-              However, a track ending due to {{MediaStreamTrack/stop()}}
-              should still reflect the {{HTMLMicrophoneElement}} state.
-            </div>
-          </li>
-          <li>
-            When the state of the monitored {{HTMLMicrophoneElement/[[track]]}}
-            changes, the user agent updates the |element|'s internal UI to
-            reflect the active, muted, or ended state of the track.
-          </li>
-          <li>
-            If {{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/readyState}}
-            becomes `"ended"`, the user agent updates its presentation
-            appropriately.
           </li>
         </ol>
 
@@ -2721,6 +2682,17 @@ onmessage = async ({data: {track}}) => {
         (or not), or that the camera and microphone might be active or muted.
       </p>
 
+      <p>The [=user agent=] is expected to monitor the state of the underlying
+        track and to continuously reflect this state in the user interface of
+        the [^usermedia^] element. For example,
+        whether the stream has been requested but is waiting for user action;
+        whether it is active or has been stopped (by any means, including
+        direct calls to {{MediaStreamTrack/stop()}}), or whether a track is
+        muted. This specification does not explicitly call out when such state
+        changes might occur, or demand a specific set of states to display to
+        the user.
+      </p>
+
       <section>
         <h4>Algorithms</h4>
 
@@ -2810,8 +2782,6 @@ onmessage = async ({data: {track}}) => {
                 <ol>
                   <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
                   <li>Set {{HTMLUserMediaElement/[[stream]]}} to |v|.</li>
-                  <li>Run the [=HTMLUserMediaElement/track monitor=]
-                    steps on [=this=].</li>
                   <li>[=AllUserMediaElements/Queue an event=] named `stream` on [=this=].</li>
                 </ol>
               </li>
@@ -2832,29 +2802,6 @@ onmessage = async ({data: {track}}) => {
                 </ol>
               </li>
             </ol>
-          </li>
-        </ol>
-
-        <p>The <dfn data-dfn-for="HTMLUserMediaElement">track monitor</dfn> steps are:</p>
-        <ol class=algorithm>
-          <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is a {{MediaStream}}.</li>
-          <li>
-            For each |track| in the result of calling {{MediaStream/getTracks()}}
-            on {{HTMLUserMediaElement/[[stream]]}}, the user agent monitors
-            the |track|'s {{MediaStreamTrack/readyState}} (specifically for
-            terminations triggered by {{MediaStreamTrack/stop()}}), its
-            {{MediaStreamTrack/enabled}} state, and its
-            {{MediaStreamTrack/muted}} state.
-          </li>
-          <li>
-            When the state of any monitored |track| changes, the user agent
-            updates the |element|'s internal UI to reflect the active, muted,
-            or ended state of the |track|.
-          </li>
-          <li>
-            If {{HTMLUserMediaElement/[[stream]]}}.{{MediaStream/active}}
-            becomes `"ended"`, the user agent reset the |element|'s internal
-            UI to its initial request state.
           </li>
         </ol>
 

--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@ partial interface MediaStreamTrack {
         <li><p>If <var>value</var>.`[[IsDetached]]` is <code>true</code>, throw a "DataCloneError" DOMException.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[agentCluster]]` to the [=ECMAScript/surrounding agent=]’s [=ECMAScript/agent cluster=].</p></li>
         <li><p>Set <var>dataHolder</var>.`[[id]]` to <var>value</var>.{{MediaStreamTrack/id}}.</p></li>
-        <li><p>Set <var>dataHolder</var>.`kind` to <var>value</var>.{{MediaStreamTrack/kind}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.`[[kind]]` to <var>value</var>.{{MediaStreamTrack/kind}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[label]]` to <var>value</var>.{{MediaStreamTrack/label}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[readyState]]` to <var>value</var>.{{MediaStreamTrack/readyState}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[enabled]]` to <var>value</var>.{{MediaStreamTrack/enabled}}.</p></li>
@@ -412,7 +412,7 @@ partial interface MediaStreamTrack {
         <li><p>If the [=ECMAScript/surrounding agent=]’s [=ECMAScript/agent cluster=] is not
           <var>dataHolder</var>.`[[agentCluster]]`, then throw a "DataCloneError" DOMException.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/id}} to <var>dataHolder</var>.`[[id]]`.</p></li>
-        <li><p>Initialize <var>track</var>.{{MediaStreamTrack/kind}} to <var>dataHolder</var>.`kind`.</p></li>
+        <li><p>Initialize <var>track</var>.{{MediaStreamTrack/kind}} to <var>dataHolder</var>.`[[kind]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/label}} to <var>dataHolder</var>.`[[label]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/readyState}} to <var>dataHolder</var>.`[[readyState]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/enabled}} to <var>dataHolder</var>.`[[enabled]]`.</p></li>
@@ -1469,7 +1469,7 @@ partial dictionary MediaTrackCapabilities {
 };
         </pre>
         </p>
-      <h3>Processing considerations</h3>
+      <h4>Processing considerations</h4>
       <p>
         When the "voiceIsolation" setting is set to <code>true</code> by the
         <a>ApplyConstraints algorithm</a>, the UA
@@ -1695,7 +1695,7 @@ partial dictionary MediaTrackSupportedConstraints {
   boolean humanFaceDetectionMode = true;
 };</pre>
       <section class="notoc">
-        <h3>Dictionary {{MediaTrackSupportedConstraints}} Members</h3>
+        <h4>Dictionary {{MediaTrackSupportedConstraints}} Members</h4>
         <dl class="dictionary-members" data-dfn-for="MediaTrackSupportedConstraints" data-link-for="MediaTrackSupportedConstraints">
           <dt><dfn>humanFaceDetectionMode</dfn> of type {{boolean}}, defaulting to <code>true</code></dt>
             <dd>See <a href=
@@ -1711,7 +1711,7 @@ partial dictionary MediaTrackCapabilities {
   sequence&lt;DOMString&gt; humanFaceDetectionMode;
 };</pre>
       <section class="notoc">
-        <h3>Dictionary {{MediaTrackCapabilities}} Members</h3>
+        <h4>Dictionary {{MediaTrackCapabilities}} Members</h4>
         <dl class="dictionary-members" data-dfn-for="MediaTrackCapabilities" data-link-for="MediaTrackCapabilities">
           <dt><dfn>humanFaceDetectionMode</dfn> of type <code>sequence&lt;{{DOMString}}&gt;</code></dt>
           <dd>
@@ -1730,7 +1730,7 @@ partial dictionary MediaTrackConstraintSet {
   ConstrainDOMString humanFaceDetectionMode;
 };</pre>
       <section class="notoc">
-        <h3>Dictionary {{MediaTrackConstraintSet}} Members</h3>
+        <h4>Dictionary {{MediaTrackConstraintSet}} Members</h4>
         <dl class="dictionary-members" data-dfn-for="MediaTrackConstraintSet" data-link-for="MediaTrackConstraintSet">
           <dt><dfn>humanFaceDetectionMode</dfn> of type {{ConstrainDOMString}}</dt>
           <dd>See <a href=
@@ -1746,7 +1746,7 @@ partial dictionary MediaTrackSettings {
   DOMString humanFaceDetectionMode;
 };</pre>
       <section class="notoc">
-        <h3>Dictionary {{MediaTrackSettings}} Members</h3>
+        <h4>Dictionary {{MediaTrackSettings}} Members</h4>
         <dl class="dictionary-members" data-dfn-for="MediaTrackSettings" data-link-for="MediaTrackSettings">
           <dt><dfn>humanFaceDetectionMode</dfn> of type {{DOMString}}</dt>
           <dd>See <a href=
@@ -1764,7 +1764,7 @@ enum HumanFaceDetectionModeEnum {
   "bounding-box-with-landmark-center-point",
 };</pre>
       <section class="notoc">
-        <h3>{{HumanFaceDetectionModeEnum}} Enumeration Description</h3>
+        <h4>{{HumanFaceDetectionModeEnum}} Enumeration Description</h4>
         <dl data-dfn-for="HumanFaceDetectionModeEnum" data-link-for="HumanFaceDetectionModeEnum">
           <dt><dfn><code>none</code></dfn></dt>
           <dd>

--- a/index.html
+++ b/index.html
@@ -1469,7 +1469,7 @@ partial dictionary MediaTrackCapabilities {
 };
         </pre>
         </p>
-      <h4>Processing considerations</h4>
+      <h3>Processing considerations</h3>
       <p>
         When the "voiceIsolation" setting is set to <code>true</code> by the
         <a>ApplyConstraints algorithm</a>, the UA
@@ -2091,8 +2091,8 @@ onmessage = async ({data: {track}}) => {
       &lt;<a>microphone</a>&gt; media capture HTML elements
     </h2>
     <p>
-      The &lt;<dfn element>usermedia</dfn>&gt;, &lt;<dfn element>camera</dfn>&gt;,
-      and &lt;<dfn element>microphone</dfn>&gt; HTML elements are [[HTML]]
+      The &lt;<dfn data-dfn-type="element">usermedia</dfn>&gt;, &lt;<dfn data-dfn-type="element">camera</dfn>&gt;,
+      and &lt;<dfn data-dfn-type="element">microphone</dfn>&gt; HTML elements are [[HTML]]
       elements that can mediate access to a {{MediaStream}}, including handling
       the required [=permission/prompts=] for [=powerful features=].
     </p>
@@ -2278,7 +2278,7 @@ onmessage = async ({data: {track}}) => {
 
       <p>
         The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
-        &lt;<a>microphone</a>&gt; <dfn for=HTMLUserMediaElement>permission name</dfn>
+        &lt;<a>microphone</a>&gt; <dfn data-dfn-for="HTMLUserMediaElement">permission name</dfn>
         are:
       </p>
       <table class="simple">
@@ -2310,7 +2310,7 @@ onmessage = async ({data: {track}}) => {
       <p>
         The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
         &lt;<a>microphone</a>&gt;
-        <dfn for=HTMLUserMediaElement>default constraints</dfn> are:
+        <dfn data-dfn-for="HTMLUserMediaElement">default constraints</dfn> are:
       </p>
       <table class="simple">
         <thead>
@@ -2364,11 +2364,11 @@ onmessage = async ({data: {track}}) => {
         </li>
       </ol>
 
-      <p>The <dfn for=HTMLUserMediaElement>activation initial</dfn> steps are:</p>
+      <p>The <dfn data-dfn-for="HTMLUserMediaElement">activation initial</dfn> steps are:</p>
       <ol class=algorithm>
         <li>[=Assert=]: |element|.{{ActivationBlockersMixin/isValid}}.</li>
         <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is null.</li>
-        <li>Let |permissionName| be |element|'s [=permission name=].</li>
+        <li>Let |permissionName| be |element|'s [=HTMLUserMediaElement/permission name=].</li>
         <li>
           Let |descriptor| be a new {{PermissionDescriptor}} with value
           &laquo;[ {{PermissionDescriptor/name}} &rarr; |permissionName| ]&raquo;.
@@ -2378,12 +2378,13 @@ onmessage = async ({data: {track}}) => {
           the [=powerful features=] described by |descriptor| with
           allowMultiple set to false.
         </li>
-        <li>If |permissionState| is not {{PermissionState/"granted"}}:</li>
-        <ol>
-          <li>Set {{HTMLUserMediaElement/[[stream]]}} to null.</li>
-          <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
-          <li>Return.</li>
-        </ol>
+        <li>If |permissionState| is not {{PermissionState/"granted"}}:
+          <ol>
+            <li>Set {{HTMLUserMediaElement/[[stream]]}} to null.</li>
+            <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
+            <li>Return.</li>
+          </ol>
+        </li>
         <li>Let |contraints| be {{HTMLUserMediaElement/[[constraints]]}}.</li>
         <li>
           Let |mediaPromise| be the result of calling
@@ -2393,14 +2394,15 @@ onmessage = async ({data: {track}}) => {
         <li>
           [=promise/React=] to |mediaPromise|:
           <ol>
-            <li>If |mediaPromise| was fulfilled with value |v|:</li>
-            <ol>
-              <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
-              <li>Set {{HTMLUserMediaElement/[[stream]]}} to |v|.</li>
-              <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
-              <li>Run the [=HTMLUserMediaElement/track monitor=] steps on |element|.</li>
-              <li>[=Fire an event=] named `stream` at |element|.</li>
-            </ol>
+            <li>If |mediaPromise| was fulfilled with value |v|:
+              <ol>
+                <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
+                <li>Set {{HTMLUserMediaElement/[[stream]]}} to |v|.</li>
+                <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
+                <li>Run the [=HTMLUserMediaElement/track monitor=] steps on |element|.</li>
+                <li>[=Fire an event=] named `stream` at |element|.</li>
+              </ol>
+            </li>
             <li>
               else:
               <ol>
@@ -2415,7 +2417,7 @@ onmessage = async ({data: {track}}) => {
         </li>
       </ol>
 
-      <p>The <dfn for=HTMLUserMediaElement>activation second</dfn> steps are:</p>
+      <p>The <dfn data-dfn-for="HTMLUserMediaElement">activation second</dfn> steps are:</p>
       <ol class=algorithm>
         <li>[=Assert=]: |element|.{{ActivationBlockersMixin/isValid}}.</li>
         <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is a {{MediaStream}}.</li>
@@ -2431,7 +2433,7 @@ onmessage = async ({data: {track}}) => {
         </li>
       </ol>
 
-      <p>The <dfn for=HTMLUserMediaElement>track monitor</dfn> steps are:</p>
+      <p>The <dfn data-dfn-for="HTMLUserMediaElement">track monitor</dfn> steps are:</p>
       <ol class=algorithm>
         <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is a {{MediaStream}}.</li>
         <li>
@@ -2454,7 +2456,7 @@ onmessage = async ({data: {track}}) => {
       </ol>
 
       <p>
-        The <dfn for=HTMLUserMediaElement>constraint filter</dfn> steps for an
+        The <dfn data-dfn-for="HTMLUserMediaElement">constraint filter</dfn> steps for an
         |element| and {{MediaStreamConstraints}} |constraints| are:
       </p>
       <ol class=algorithm>

--- a/index.html
+++ b/index.html
@@ -2177,7 +2177,9 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>
-            Set [=this=].{{HTMLCameraElement/[[constraints]]}} to |constraints|.
+            Set [=this=].{{HTMLCameraElement/[[constraints]]}} to |constraints|
+            to the result of [=HTMLCameraElement/constraint filter=] with
+            |constraints|.
           </li>
         </ol>
 
@@ -2408,7 +2410,8 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>
-            Set [=this=].{{HTMLMicrophoneElement/[[constraints]]}} to |constraints|.
+            Set [=this=].{{HTMLMicrophoneElement/[[constraints]]}} to the result
+            of [=HTMLMicrophoneElement/constraint filter=] with |constraints|.
           </li>
         </ol>
 

--- a/index.html
+++ b/index.html
@@ -2119,6 +2119,7 @@ onmessage = async ({data: {track}}) => {
         attribute EventHandler onstream;
         attribute EventHandler ontrackchange;
       };
+      HTMLCameraElement includes PowerfulFeatureObserver;
       </pre>
 
       <p>The &lt;<a>camera</a>&gt; element uses the following internal slots:</p>
@@ -2156,6 +2157,10 @@ onmessage = async ({data: {track}}) => {
         </dt>
         <dd>&mdash; all global content attributes.</dd>
         <dt>
+          <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-powerfulfeatureobserver-attributes">PowerfulFeatureObserver attributes</a>
+        </dt>
+        <dd>&mdash; attributes provided by the PowerfulFeatureObserver mixin.</dd>
+        <dt>
           <dfn data-dfn-for="HTMLCameraElement">autostart</dfn>
         </dt>
         <dd>&mdash; A boolean attribute indicating whether to try to start the stream automatically as the element is added to the DOM and rendered.</dd>
@@ -2172,6 +2177,8 @@ onmessage = async ({data: {track}}) => {
           <li>Initialize {{HTMLCameraElement/[[track]]}} to null.</li>
           <li>Initialize {{HTMLCameraElement/[[error]]}} to null.</li>
           <li>Initialize {{HTMLCameraElement/[[constraints]]}} to [=this=]'s [=HTMLCameraElement/default constraints=].</li>
+          <li>Initialize {{PowerfulFeatureObserver/[[Features]]}} to &laquo; "camera" &raquo;.</li>
+          <li>Run <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver">PowerfulFeatureObserver</a>'s <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-initialization-steps">initialization steps</a>.</li>
         </ol>
 
         <p>The &lt;<a>camera</a>&gt; element's [=insertion steps=], given |element|, are:</p>
@@ -2354,6 +2361,7 @@ onmessage = async ({data: {track}}) => {
         attribute EventHandler onstream;
         attribute EventHandler ontrackchange;
       };
+      HTMLMicrophoneElement includes PowerfulFeatureObserver;
       </pre>
 
       <p>The &lt;<a>microphone</a>&gt; element uses the following internal slots:</p>
@@ -2391,6 +2399,10 @@ onmessage = async ({data: {track}}) => {
         </dt>
         <dd>&mdash; all global content attributes.</dd>
         <dt>
+          <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-powerfulfeatureobserver-attributes">PowerfulFeatureObserver attributes</a>
+        </dt>
+        <dd>&mdash; attributes provided by the PowerfulFeatureObserver mixin.</dd>
+        <dt>
           <dfn data-dfn-for="HTMLMicrophoneElement">autostart</dfn>
         </dt>
         <dd>&mdash; A boolean attribute indicating whether to try to start the stream automatically as the element is added to the DOM and rendered.</dd>
@@ -2407,6 +2419,8 @@ onmessage = async ({data: {track}}) => {
           <li>Initialize {{HTMLMicrophoneElement/[[track]]}} to null.</li>
           <li>Initialize {{HTMLMicrophoneElement/[[error]]}} to null.</li>
           <li>Initialize {{HTMLMicrophoneElement/[[constraints]]}} to [=this=]'s [=HTMLMicrophoneElement/default constraints=].</li>
+          <li>Initialize {{PowerfulFeatureObserver/[[Features]]}} to &laquo; "microphone" &raquo;.</li>
+          <li>Run <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver">PowerfulFeatureObserver</a>'s <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-initialization-steps">initialization steps</a>.</li>
         </ol>
 
         <p>The &lt;<a>microphone</a>&gt; element's [=insertion steps=], given |element|, are:</p>
@@ -2594,6 +2608,7 @@ onmessage = async ({data: {track}}) => {
         attribute EventHandler onstream;
         attribute EventHandler ontrackchange;
       };
+      HTMLUserMediaElement includes PowerfulFeatureObserver;
       </pre>
 
       <p>The &lt;<a>usermedia</a>&gt; element uses the following internal slots:</p>
@@ -2631,6 +2646,10 @@ onmessage = async ({data: {track}}) => {
         </dt>
         <dd>&mdash; all global content attributes.</dd>
         <dt>
+          <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-powerfulfeatureobserver-attributes">PowerfulFeatureObserver attributes</a>
+        </dt>
+        <dd>&mdash; attributes provided by the PowerfulFeatureObserver mixin.</dd>
+        <dt>
           <dfn data-dfn-for="HTMLUserMediaElement">autostart</dfn>
         </dt>
         <dd>&mdash; A boolean attribute indicating whether to try to start the stream automatically as the element is added to the DOM and rendered.</dd>
@@ -2647,6 +2666,8 @@ onmessage = async ({data: {track}}) => {
           <li>Initialize {{HTMLUserMediaElement/[[stream]]}} to null.</li>
           <li>Initialize {{HTMLUserMediaElement/[[error]]}} to null.</li>
           <li>Initialize {{HTMLUserMediaElement/[[constraints]]}} to [=this=]'s [=HTMLUserMediaElement/default constraints=].</li>
+          <li>Initialize {{PowerfulFeatureObserver/[[Features]]}} to &laquo; "camera", "microphone" &raquo;.</li>
+          <li>Run <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver">PowerfulFeatureObserver</a>'s <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-initialization-steps">initialization steps</a>.</li>
         </ol>
 
         <p>The &lt;<a>usermedia</a>&gt; element's [=insertion steps=], given |element|, are:</p>

--- a/index.html
+++ b/index.html
@@ -1233,7 +1233,7 @@ partial dictionary VideoFrameMetadata {
       When the <dfn class="abstract-op">Initialize Video Frame Timestamps From Internal MediaStreamTrack Video Frame</dfn>
       algorithm is invoked with |frame| and |offset| as input, run the following steps.
       <ol class=algorithm>
-        <li>Set {{VideoFrame/timestamp}} from [=presentation timestamp=] minus |offset|.</li>
+          <li>Set {{VideoFrame/timestamp}} from [=presentation timestamp=] minus |offset|.</li>
         <li>Set {{VideoFrameMetadata/captureTime}} from [=capture timestamp=] if set.</li>
         <li>Set {{VideoFrameMetadata/receiveTime}} from [=receive timestamp=] if set.</li>
         <li>Set {{VideoFrameMetadata/rtpTimestamp}} from [=RTP timestamp=] if set.</li>
@@ -1241,7 +1241,7 @@ partial dictionary VideoFrameMetadata {
       When the <dfn class="abstract-op">Copy Video Frame Timestamps To Internal MediaStreamTrack Video Frame</dfn>
       algorithm runs with |frame| as input, run the following steps.
       <ol class=algorithm>
-        <li>Set [=presentation timestamp=] from {{VideoFrame/timestamp}}.</li>
+          <li>Set [=presentation timestamp=] from {{VideoFrame/timestamp}}.</li>
         <li>Set [=capture timestamp=] from {{VideoFrameMetadata/captureTime}} if [=map/exist|present=].</li>
         <li>Set [=receive timestamp=] from {{VideoFrameMetadata/receiveTime}} if [=map/exist|present=].</li>
         <li>Set [=RTP timestamp=] from {{VideoFrameMetadata/rtpTimestamp}} if [=map/exist|present=].</li>
@@ -2086,401 +2086,711 @@ onmessage = async ({data: {track}}) => {
   </section>
 
   <section>
-    <h2>
-      The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
-      &lt;<a>microphone</a>&gt; media capture HTML elements
-    </h2>
+    <h2>Media capture HTML elements</h2>
     <p>
-      The &lt;<dfn data-dfn-type="element">usermedia</dfn>&gt;, &lt;<dfn data-dfn-type="element">camera</dfn>&gt;,
-      and &lt;<dfn data-dfn-type="element">microphone</dfn>&gt; HTML elements are [[HTML]]
-      elements that can mediate access to a {{MediaStream}}, including handling
-      the required [=permission/prompts=] for [=powerful features=].
+      The following are [[HTML]] elements that let the user turn on camera and/or microphone, including handling the required [=permission/prompts=] for [=powerful features=].
     </p>
     <p>
-      These three elements cover three different use cases and allow for use
-      case specific user interfaces in the [=user agent=]. Their
-      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">content attributes</a>
-      and IDL are mostly the same.
+      They cover different use cases and allow for use case specific user interfaces in the [=user agent=].
     </p>
-    <p>
-      The &lt;<a>usermedia</a>&gt; element uses the following
-      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
-    </p>
-    <pre class=idl>
+
+    <section>
+      <h3>The &lt;<a>camera</a>&gt; HTML element</h3>
+      <p>
+        The &lt;<dfn data-dfn-type="element">camera</dfn>&gt; HTML element is an [[HTML]]
+        element that can mediate access to a camera's video {{MediaStreamTrack}}, including handling
+        the required [=permission/prompts=] for [=powerful features=].
+      </p>
+      <p>
+        The &lt;<a>camera</a>&gt; element uses the following
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
+      </p>
+      <pre class=idl>
+      [Exposed=Window]
+      interface HTMLCameraElement : HTMLElement {
+        [HTMLConstructor] constructor();
+
+        readonly attribute MediaStreamTrack? track;
+        undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
+        readonly attribute any error;
+
+        attribute boolean autostart;
+
+        attribute EventHandler onstream;
+        attribute EventHandler ontrackchange;
+      };
+      </pre>
+
+      <p>The &lt;<a>camera</a>&gt; element uses the following internal slots:</p>
+      <ul>
+        <li>
+          <dfn data-dfn-for="HTMLCameraElement">[[\track]]</dfn> &mdash;
+          Holds null or a {{MediaStreamTrack}}.
+        </li>
+        <li>
+          <dfn data-dfn-for="HTMLCameraElement">[[\constraints]]</dfn> &mdash;
+          Holds a {{MediaTrackConstraintSet}}.
+        </li>
+        <li>
+          <dfn data-dfn-for="HTMLCameraElement">[[\error]]</dfn> &mdash;
+          Holds a {{DOMException}} or null.
+        </li>
+      </ul>
+
+      <p>
+        The &lt;<a>camera</a>&gt; element belongs to the [=flow content=],
+        [=phrasing content=], [=interactive content=], and [=palpable content=]
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">categories</a>.
+        It can be used in contexts where [=phrasing content=] is expected. Its
+        content, if any, is its
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#fallback-content">fallback content</a>.
+      </p>
+
+      <p>
+        The &lt;<a>camera</a>&gt; element supports the following
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">content attributes</a>:
+      </p>
+      <dl>
+        <dt>
+          <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">global attributes</a>
+        </dt>
+        <dd>&mdash; all global content attributes.</dd>
+        <dt>
+          <dfn data-dfn-for="HTMLCameraElement">autostart</dfn>
+        </dt>
+        <dd>&mdash; A boolean attribute indicating whether to try to start the stream automatically as the element is added to the DOM and rendered.</dd>
+
+      </dl>
+
+      <section>
+        <h4>Algorithms</h4>
+
+        <p>
+          The {{HTMLCameraElement/constructor()}} steps are:
+        </p>
+        <ol class=algorithm>
+          <li>Initialize {{HTMLCameraElement/[[track]]}} to null.</li>
+          <li>Initialize {{HTMLCameraElement/[[error]]}} to null.</li>
+          <li>Initialize {{HTMLCameraElement/[[constraints]]}} to [=this=]'s [=HTMLCameraElement/default constraints=].</li>
+        </ol>
+
+        <p>The &lt;<a>camera</a>&gt; element's [=insertion steps=], given |element|, are:</p>
+        <ol class=algorithm>
+          <li>
+            If |element| has an {{HTMLCameraElement/autostart}} attribute, and {{HTMLCameraElement/[[track]]}} is null,
+            run the [=HTMLCameraElement/activation initial=] steps on |element|.
+          </li>
+        </ol>
+
+        <p>The {{HTMLCameraElement/track}} <a>getter</a> steps are:</p>
+        <ol class=algorithm>
+          <li>Return {{HTMLCameraElement/[[track]]}}.</li>
+        </ol>
+
+        <p>
+          The {{HTMLCameraElement/setConstraints()}} steps for an |element| and
+          an optional |constraints| parameter are:
+        </p>
+        <ol class=algorithm>
+          <li>
+            Set {{HTMLCameraElement/[[constraints]]}} to the result of
+            [=HTMLCameraElement/constraint filter=] for |element| and
+            |constraints|.
+          </li>
+        </ol>
+
+        <p>The {{HTMLCameraElement/error}} <a>getter</a> steps are:</p>
+        <ol class=algorithm>
+          <li>Return {{HTMLCameraElement/[[error]]}}.</li>
+        </ol>
+
+        <p>
+          The &lt;<a>camera</a>&gt; <dfn data-dfn-for="HTMLCameraElement">permission name</dfn>
+          is: [=/"camera"=].
+        </p>
+
+        <p>
+          The &lt;<a>camera</a>&gt;
+          <dfn data-dfn-for="HTMLCameraElement">default constraints</dfn> are:
+          &laquo;[ ]&raquo;.
+        </p>
+
+        <p>
+          The &lt;<a>camera</a>&gt; element's [=EventTarget/activation behavior=],
+          given |element|, is:
+        </p>
+        <ol class=algorithm>
+          <li>
+            If {{HTMLCameraElement/[[track]]}} is null, run
+            [=HTMLCameraElement/activation initial=] steps.
+          </li>
+          <li>
+            Otherwise, run [=HTMLCameraElement/activation second=] steps.
+          </li>
+        </ol>
+
+        <p>The <dfn data-dfn-for="HTMLCameraElement">activation initial</dfn> steps are:</p>
+        <ol class=algorithm>
+          <li>[=Assert=]: {{HTMLCameraElement/[[track]]}} is null.</li>
+          <li>Let |permissionName| be |element|'s [=HTMLCameraElement/permission name=].</li>
+          <li>
+            Let |descriptor| be a new {{PermissionDescriptor}} with value
+            &laquo;[ {{PermissionDescriptor/name}} &rarr; |permissionName| ]&raquo;.
+          </li>
+          <li>
+            Let |permissionState| be the result of [=request permission to use=]
+            the [=powerful features=] described by |descriptor| with
+            allowMultiple set to false.
+          </li>
+          <li>If |permissionState| is not {{PermissionState/"granted"}}:
+            <ol>
+              <li>Set {{HTMLCameraElement/[[track]]}} to null.</li>
+              <li>Set {{HTMLCameraElement/[[error]]}} to null.</li>
+              <li>Return.</li>
+            </ol>
+          </li>
+          <li>Let |constraints| be {{HTMLCameraElement/[[constraints]]}}.</li>
+          <li>
+            Let |filteredConstraints| be the result of [=HTMLCameraElement/constraint filter=] for |element| and |constraints|.
+          </li>
+          <li>
+            Let |mediaPromise| be the result of calling
+            {{MediaDevices/getUserMedia()}} with |filteredConstraints| as its first
+            argument.
+          </li>
+          <li>
+            [=promise/React=] to |mediaPromise|:
+            <ol>
+              <li>If |mediaPromise| was fulfilled with value |v|:
+                <ol>
+                  <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
+                  <li>Let |tracks| be the result of calling {{MediaStream/getVideoTracks()}} on |v|.</li>
+                  <li>If |tracks| is empty, set {{HTMLCameraElement/[[track]]}} to null. Otherwise, set {{HTMLCameraElement/[[track]]}} to |tracks|[0].</li>
+                  <li>Set {{HTMLCameraElement/[[error]]}} to null.</li>
+                  <li>Run the [=HTMLCameraElement/track monitor=] steps on |element|.</li>
+                  <li>[=Fire an event=] named `stream` at |element|.</li>
+                </ol>
+              </li>
+              <li>
+                else:
+                <ol>
+                  <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
+                  <li>[=Assert=]: |r| is a |DOMException|.</li>
+                  <li>Set {{HTMLCameraElement/[[track]]}} to null.</li>
+                  <li>Set {{HTMLCameraElement/[[error]]}} to |r|.</li>
+                  <li>[=Fire an event=] named `stream` at |element|.</li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+
+        <p>The <dfn data-dfn-for="HTMLCameraElement">activation second</dfn> steps are:</p>
+        <ol class=algorithm>
+          <li>[=Assert=]: {{HTMLCameraElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
+          <li>
+            Set {{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/enabled}} to the negation of
+            {{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/enabled}}.
+          </li>
+        </ol>
+
+        <p>The <dfn data-dfn-for="HTMLCameraElement">track monitor</dfn> steps are:</p>
+        <ol class=algorithm>
+          <li>[=Assert=]: {{HTMLCameraElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
+          <li>
+            The user agent MUST monitor the {{HTMLCameraElement/[[track]]}}'s
+            {{MediaStreamTrack/readyState}} (specifically for
+            terminations triggered by {{MediaStreamTrack/stop()}}), its
+            {{MediaStreamTrack/enabled}} state, and its
+            {{MediaStreamTrack/muted}} state.
+          </li>
+          <li>
+            When the state of the monitored {{HTMLCameraElement/[[track]]}} changes, the user agent MUST update the |element|'s
+            internal UI to reflect the active, muted, or ended state of the track, and [=Fire an event=] named `trackchange` at |element|.
+          </li>
+          <li>
+            If {{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/readyState}} becomes `"ended"`, the user agent MUST
+            set {{HTMLCameraElement/[[track]]}} to null and reset the |element|'s
+            internal UI to its initial request state.
+          </li>
+        </ol>
+
+        <p>
+          The <dfn data-dfn-for="HTMLCameraElement">constraint filter</dfn> steps for an
+          |element| and a {{MediaTrackConstraintSet}} |constraints| are:
+        </p>
+        <ol class=algorithm>
+          <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>
+          <li>Set |result|["audio"] to false.</li>
+          <li>Set |result|["video"] to a copy of |constraints|.</li>
+          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["video"].</li>
+          <li>Return |result|.</li>
+        </ol>
+      </section>
+    </section>
+
+    <section>
+      <h3>The &lt;<a>microphone</a>&gt; HTML element</h3>
+      <p>
+        The &lt;<dfn data-dfn-type="element">microphone</dfn>&gt; HTML element is an [[HTML]]
+        element that can mediate access to a microphone's audio {{MediaStreamTrack}}, including handling
+        the required [=permission/prompts=] for [=powerful features=].
+      </p>
+      <p>
+        The &lt;<a>microphone</a>&gt; element uses the following
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
+      </p>
+      <pre class=idl>
+      [Exposed=Window]
+      interface HTMLMicrophoneElement : HTMLElement {
+        [HTMLConstructor] constructor();
+
+        readonly attribute MediaStreamTrack? track;
+        undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
+        readonly attribute any error;
+
+        attribute boolean autostart;
+
+        attribute EventHandler onstream;
+        attribute EventHandler ontrackchange;
+      };
+      </pre>
+
+      <p>The &lt;<a>microphone</a>&gt; element uses the following internal slots:</p>
+      <ul>
+        <li>
+          <dfn data-dfn-for="HTMLMicrophoneElement">[[\track]]</dfn> &mdash;
+          Holds null or a {{MediaStreamTrack}}.
+        </li>
+        <li>
+          <dfn data-dfn-for="HTMLMicrophoneElement">[[\constraints]]</dfn> &mdash;
+          Holds a {{MediaTrackConstraintSet}}.
+        </li>
+        <li>
+          <dfn data-dfn-for="HTMLMicrophoneElement">[[\error]]</dfn> &mdash;
+          Holds a {{DOMException}} or null.
+        </li>
+      </ul>
+
+      <p>
+        The &lt;<a>microphone</a>&gt; element belongs to the [=flow content=],
+        [=phrasing content=], [=interactive content=], and [=palpable content=]
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">categories</a>.
+        It can be used in contexts where [=phrasing content=] is expected. Its
+        content, if any, is its
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#fallback-content">fallback content</a>.
+      </p>
+
+      <p>
+        The &lt;<a>microphone</a>&gt; element supports the following
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">content attributes</a>:
+      </p>
+      <dl>
+        <dt>
+          <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">global attributes</a>
+        </dt>
+        <dd>&mdash; all global content attributes.</dd>
+        <dt>
+          <dfn data-dfn-for="HTMLMicrophoneElement">autostart</dfn>
+        </dt>
+        <dd>&mdash; A boolean attribute indicating whether to try to start the stream automatically as the element is added to the DOM and rendered.</dd>
+
+      </dl>
+
+      <section>
+        <h4>Algorithms</h4>
+
+        <p>
+          The {{HTMLMicrophoneElement/constructor()}} steps are:
+        </p>
+        <ol class=algorithm>
+          <li>Initialize {{HTMLMicrophoneElement/[[track]]}} to null.</li>
+          <li>Initialize {{HTMLMicrophoneElement/[[error]]}} to null.</li>
+          <li>Initialize {{HTMLMicrophoneElement/[[constraints]]}} to [=this=]'s [=HTMLMicrophoneElement/default constraints=].</li>
+        </ol>
+
+        <p>The &lt;<a>microphone</a>&gt; element's [=insertion steps=], given |element|, are:</p>
+        <ol class=algorithm>
+          <li>
+            If |element| has an {{HTMLMicrophoneElement/autostart}} attribute, and {{HTMLMicrophoneElement/[[track]]}} is null,
+            run the [=HTMLMicrophoneElement/activation initial=] steps on |element|.
+          </li>
+        </ol>
+
+        <p>The {{HTMLMicrophoneElement/track}} <a>getter</a> steps are:</p>
+        <ol class=algorithm>
+          <li>Return {{HTMLMicrophoneElement/[[track]]}}.</li>
+        </ol>
+
+        <p>
+          The {{HTMLMicrophoneElement/setConstraints()}} steps for an |element| and
+          an optional |constraints| parameter are:
+        </p>
+        <ol class=algorithm>
+          <li>
+            Set {{HTMLMicrophoneElement/[[constraints]]}} to the result of
+            [=HTMLMicrophoneElement/constraint filter=] for |element| and
+            |constraints|.
+          </li>
+        </ol>
+
+        <p>The {{HTMLMicrophoneElement/error}} <a>getter</a> steps are:</p>
+        <ol class=algorithm>
+          <li>Return {{HTMLMicrophoneElement/[[error]]}}.</li>
+        </ol>
+
+        <p>
+          The &lt;<a>microphone</a>&gt; <dfn data-dfn-for="HTMLMicrophoneElement">permission name</dfn>
+          is: [=/"microphone"=].
+        </p>
+
+        <p>
+          The &lt;<a>microphone</a>&gt;
+          <dfn data-dfn-for="HTMLMicrophoneElement">default constraints</dfn> are:
+          &laquo;[ ]&raquo;.
+        </p>
+
+        <p>
+          The &lt;<a>microphone</a>&gt; element's [=EventTarget/activation behavior=],
+          given |element|, is:
+        </p>
+        <ol class=algorithm>
+          <li>
+            If {{HTMLMicrophoneElement/[[track]]}} is null, run
+            [=HTMLMicrophoneElement/activation initial=] steps.
+          </li>
+          <li>
+            Otherwise, run [=HTMLMicrophoneElement/activation second=] steps.
+          </li>
+        </ol>
+
+        <p>The <dfn data-dfn-for="HTMLMicrophoneElement">activation initial</dfn> steps are:</p>
+        <ol class=algorithm>
+          <li>[=Assert=]: {{HTMLMicrophoneElement/[[track]]}} is null.</li>
+          <li>Let |permissionName| be |element|'s [=HTMLMicrophoneElement/permission name=].</li>
+          <li>
+            Let |descriptor| be a new {{PermissionDescriptor}} with value
+            &laquo;[ {{PermissionDescriptor/name}} &rarr; |permissionName| ]&raquo;.
+          </li>
+          <li>
+            Let |permissionState| be the result of [=request permission to use=]
+            the [=powerful features=] described by |descriptor| with
+            allowMultiple set to false.
+          </li>
+          <li>If |permissionState| is not {{PermissionState/"granted"}}:
+            <ol>
+              <li>Set {{HTMLMicrophoneElement/[[track]]}} to null.</li>
+              <li>Set {{HTMLMicrophoneElement/[[error]]}} to null.</li>
+              <li>Return.</li>
+            </ol>
+          </li>
+          <li>Let |constraints| be {{HTMLMicrophoneElement/[[constraints]]}}.</li>
+          <li>
+            Let |filteredConstraints| be the result of [=HTMLMicrophoneElement/constraint filter=] for |element| and |constraints|.
+          </li>
+          <li>
+            Let |mediaPromise| be the result of calling
+            {{MediaDevices/getUserMedia()}} with |filteredConstraints| as its first
+            argument.
+          </li>
+          <li>
+            [=promise/React=] to |mediaPromise|:
+            <ol>
+              <li>If |mediaPromise| was fulfilled with value |v|:
+                <ol>
+                  <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
+                  <li>Let |tracks| be the result of calling {{MediaStream/getAudioTracks()}} on |v|.</li>
+                  <li>If |tracks| is empty, set {{HTMLMicrophoneElement/[[track]]}} to null. Otherwise, set {{HTMLMicrophoneElement/[[track]]}} to |tracks|[0].</li>
+                  <li>Set {{HTMLMicrophoneElement/[[error]]}} to null.</li>
+                  <li>Run the [=HTMLMicrophoneElement/track monitor=] steps on |element|.</li>
+                  <li>[=Fire an event=] named `stream` at |element|.</li>
+                </ol>
+              </li>
+              <li>
+                else:
+                <ol>
+                  <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
+                  <li>[=Assert=]: |r| is a |DOMException|.</li>
+                  <li>Set {{HTMLMicrophoneElement/[[track]]}} to null.</li>
+                  <li>Set {{HTMLMicrophoneElement/[[error]]}} to |r|.</li>
+                  <li>[=Fire an event=] named `stream` at |element|.</li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+
+        <p>The <dfn data-dfn-for="HTMLMicrophoneElement">activation second</dfn> steps are:</p>
+        <ol class=algorithm>
+          <li>[=Assert=]: {{HTMLMicrophoneElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
+          <li>
+            Set {{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/enabled}} to the negation of
+            {{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/enabled}}.
+          </li>
+        </ol>
+
+        <p>The <dfn data-dfn-for="HTMLMicrophoneElement">track monitor</dfn> steps are:</p>
+        <ol class=algorithm>
+          <li>[=Assert=]: {{HTMLMicrophoneElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
+          <li>
+            The user agent MUST monitor the {{HTMLMicrophoneElement/[[track]]}}'s
+            {{MediaStreamTrack/readyState}} (specifically for
+            terminations triggered by {{MediaStreamTrack/stop()}}), its
+            {{MediaStreamTrack/enabled}} state, and its
+            {{MediaStreamTrack/muted}} state.
+          </li>
+          <li>
+            When the state of the monitored {{HTMLMicrophoneElement/[[track]]}} changes, the user agent MUST update the |element|'s
+            internal UI to reflect the active, muted, or ended state of the track, and [=Fire an event=] named `trackchange` at |element|.
+          </li>
+          <li>
+            If {{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/readyState}} becomes `"ended"`, the user agent MUST
+            set {{HTMLMicrophoneElement/[[track]]}} to null and reset the |element|'s
+            internal UI to its initial request state.
+          </li>
+        </ol>
+
+        <p>
+          The <dfn data-dfn-for="HTMLMicrophoneElement">constraint filter</dfn> steps for an
+          |element| and a {{MediaTrackConstraintSet}} |constraints| are:
+        </p>
+        <ol class=algorithm>
+          <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>
+          <li>Set |result|["audio"] to a copy of |constraints|.</li>
+          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["audio"].</li>
+          <li>Set |result|["video"] to false.</li>
+          <li>Return |result|.</li>
+        </ol>
+      </section>
+    </section>
+
+    <section>
+      <h3>The &lt;<a>usermedia</a>&gt; HTML element</h3>
+      <p>
+        The &lt;<dfn data-dfn-type="element">usermedia</dfn>&gt; HTML element is an [[HTML]]
+        element that can mediate access to a {{MediaStream}} consisting of one or more tracks, including handling
+        the required [=permission/prompts=] for [=powerful features=].
+      </p>
+      <p>
+        The &lt;<a>usermedia</a>&gt; element uses the following
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
+      </p>
+      <pre class=idl>
+      dictionary HTMLMediaStreamConstraints {
+        MediaTrackConstraintSet video;
+        MediaTrackConstraintSet audio;
+      };
+
       [Exposed=Window]
       interface HTMLUserMediaElement : HTMLElement {
         [HTMLConstructor] constructor();
 
         readonly attribute MediaStream? stream;
-        undefined setConstraints(MediaStreamConstraints constraints);
+        undefined setConstraints(optional HTMLMediaStreamConstraints constraints = {});
         readonly attribute any error;
 
         attribute boolean autostart;
 
         attribute EventHandler onstream;
-        attribute EventHandler ontrackchanged;
+        attribute EventHandler ontrackchange;
       };
-      HTMLUserMediaElement includes ActivationBlockersMixin;
-    </pre>
-    <p>
-      The &lt;<a>camera</a>&gt; and &lt;<a>microphone</a>&gt;
-      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interfaces</a>
-      are almost the same. The &lt;<a>camera</a>&gt; element uses the following
-      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
-    </p>
-    <pre class=idl>
-      [Exposed=Window]
-      interface HTMLCameraElement : HTMLElement {
-        [HTMLConstructor] constructor();
+      </pre>
 
-        readonly attribute MediaStream? stream;
-        undefined setConstraints(MediaStreamConstraints constraints);
-        readonly attribute any error;
-
-        attribute boolean autostart;
-
-        attribute EventHandler onstream;
-        attribute EventHandler ontrackchanged;
-      };
-      HTMLCameraElement includes ActivationBlockersMixin;
-    </pre>
-    <p>
-      The &lt;<a>microphone</a>&gt; element uses the following
-      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
-    </p>
-    <pre class=idl>
-      [Exposed=Window]
-      interface HTMLMicrophoneElement : HTMLElement {
-        [HTMLConstructor] constructor();
-
-        readonly attribute MediaStream? stream;
-        undefined setConstraints(MediaStreamConstraints constraints);
-        readonly attribute any error;
-
-        attribute boolean autostart;
-
-        attribute EventHandler onstream;
-        attribute EventHandler ontrackchanged;
-      };
-      HTMLMicrophoneElement includes ActivationBlockersMixin;
-    </pre>
-
-    <p>The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and &lt;<a>microphone</a>&gt; elements all use the following internal slots:</p>
-    <ul>
-      <li>
-        <dfn data-dfn-for="HTMLUserMediaElement">[[\stream]]</dfn> &mdash;
-        Holds null or a {{MediaStream}}.
-      </li>
-      <li>
-        <dfn data-dfn-for="HTMLUserMediaElement">[[\constraints]]</dfn> &mdash;
-        Holds a {{MediaStreamConstraints}}.
-      </li>
-      <li>
-        <dfn data-dfn-for="HTMLUserMediaElement">[[\error]]</dfn> &mdash;
-        Holds a {{DOMException}}, an {{OverconstrainedError}} or null.
-      </li>
-    </ul>
-
-    <p>
-      The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
-      &lt;<a>microphone</a>&gt; elements belong to the [=flow content=],
-      [=phrasing content=], [=interactive content=], and [=palpable content=]
-      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">categories</a>.
-      They can be used in contexts where [=phrasing content=] is expected. Their
-      content, if any, are their
-      <a href="https://html.spec.whatwg.org/multipage/dom.html#fallback-content">fallback content</a>.
-      They use the {{ActivationBlockersMixin}} from [[geolocation-element]], to
-      provide protection against programmatic activation.
-    </p>
-
-    <p>
-      The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
-      &lt;<a>microphone</a>&gt; elements all support the following
-      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">content attributes</a>:
-    </p>
-    <dl>
-      <dt>
-        <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">global attributes</a>
-      </dt>
-      <dd>&mdash; all global content attributes.</dd>
-      <dt>
-        <dfn data-dfn-for="HTMLUserMediaElement">autostart</dfn>
-      </dt>
-      <dd>&mdash; A boolean attribute indicating whether to try to start the stream automatically as the element is added to the DOM and rendered.</dd>
-      <dt>
-        <a href="https://wicg.github.io/PEPC/geolocation-element.html#dom-activationblockersmixin-isvalid">isValid</a>
-      </dt>
-      <dt>
-        <a href="https://wicg.github.io/PEPC/geolocation-element.html#dom-activationblockersmixin-invalidreason">invalidReason</a>
-      </dt>
-      <dt>
-        <a href="https://wicg.github.io/PEPC/geolocation-element.html#dom-activationblockersmixin-onvalidationstatuschange">onvalidationstatuschange</a>
-      </dt>
-      <dd>&mdash; content attributes from {{ActivationBlockersMixin}}</dd>
-    </dl>
-
-    <section>
-      <h3>Algorithms</h3>
+      <p>The &lt;<a>usermedia</a>&gt; element uses the following internal slots:</p>
+      <ul>
+        <li>
+          <dfn data-dfn-for="HTMLUserMediaElement">[[\stream]]</dfn> &mdash;
+          Holds null or a {{MediaStream}}.
+        </li>
+        <li>
+          <dfn data-dfn-for="HTMLUserMediaElement">[[\constraints]]</dfn> &mdash;
+          Holds an {{HTMLMediaStreamConstraints}}.
+        </li>
+        <li>
+          <dfn data-dfn-for="HTMLUserMediaElement">[[\error]]</dfn> &mdash;
+          Holds a {{DOMException}} or null.
+        </li>
+      </ul>
 
       <p>
-        The {{HTMLUserMediaElement}}, {{HTMLCameraElement}}, and
-        {{HTMLMicrophoneElement}} all use the same constructor steps. Their
-        {{HTMLUserMediaElement/constructor()}} steps are:
+        The &lt;<a>usermedia</a>&gt; element belongs to the [=flow content=],
+        [=phrasing content=], [=interactive content=], and [=palpable content=]
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">categories</a>.
+        It can be used in contexts where [=phrasing content=] is expected. Its
+        content, if any, is its
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#fallback-content">fallback content</a>.
       </p>
-      <ol class=algorithm>
-        <li>Run {{ActivationBlockersMixin}}'s [=ActivationBlockersMixin/initialization steps=].</li>
-        <li>Initialize {{HTMLUserMediaElement/[[stream]]}} to null.</li>
-        <li>Initialize {{HTMLUserMediaElement/[[error]]}} to null.</li>
-        <li>Initialize {{HTMLUserMediaElement/[[constraints]]}} to [=this=]'s [=HTMLUserMediaElement/default constraints=].</li>
-      </ol>
-
-      <p>The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and &lt;<a>microphone</a>&gt; elements' [=insertion steps=], given |element|, are:</p>
-      <ol class=algorithm>
-        <li>
-          Run {{ActivationBlockersMixin}}'s
-          [=ActivationBlockersMixin/insertion steps=] given |element|.
-        </li>
-        <li>
-          If |element| has an {{HTMLUserMediaElement/autostart}} attribute, and {{HTMLUserMediaElement/[[stream]]}} is null,
-          run the [=HTMLUserMediaElement/activation initial=] steps on |element|.
-        </li>
-      </ol>
-
-      <p>The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and &lt;<a>microphone</a>&gt; elements' [=removing steps=], given |element|, are:</p>
-      <ol class=algorithm>
-        <li>
-          Run {{ActivationBlockersMixin}}'s
-          [=ActivationBlockersMixin/removing steps=] given |element|.
-        </li>
-      </ol>
-
-      <p>The {{HTMLUserMediaElement/stream}} <a>getter</a> steps are:</p>
-      <ol class=algorithm>
-        <li>Return {{HTMLUserMediaElement/[[stream]]}}.</li>
-      </ol>
 
       <p>
-        The {{HTMLUserMediaElement/setConstraints()}} steps for an |element| and
-        a parameter |constraints| steps:
+        The &lt;<a>usermedia</a>&gt; element supports the following
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">content attributes</a>:
       </p>
-      <ol class=algorithm>
-        <li>
-          Set {{HTMLUserMediaElement/[[constraints]]}} to the result of
-          [=HTMLUserMediaElement/constraint filter=] for |element| and
-          |constraints|.
-        </li>
-      </ol>
+      <dl>
+        <dt>
+          <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">global attributes</a>
+        </dt>
+        <dd>&mdash; all global content attributes.</dd>
+        <dt>
+          <dfn data-dfn-for="HTMLUserMediaElement">autostart</dfn>
+        </dt>
+        <dd>&mdash; A boolean attribute indicating whether to try to start the stream automatically as the element is added to the DOM and rendered.</dd>
 
-      <p>The {{HTMLUserMediaElement/error}} <a>getter</a> steps are:</p>
-      <ol class=algorithm>
-        <li>Return {{HTMLUserMediaElement/[[error]]}}.</li>
-      </ol>
+      </dl>
 
-      <p>
-        The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
-        &lt;<a>microphone</a>&gt; <dfn data-dfn-for="HTMLUserMediaElement">permission name</dfn>
-        are:
-      </p>
-      <table class="simple">
-        <thead>
-          <tr>
-            <th>Element type</th>
-            <th>Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th>&lt;<a>usermedia</a>&gt;</th>
-            <td>
-              The [=string/concatenate|concatentation=] of &laquo; [=/"camera"=],
-              " ", [=/"microphone"=] &raquo;.
-            </td>
-          </tr>
-          <tr>
-            <th>&lt;<a>camera</a>&gt;</th>
-            <td>[=/"camera"=]</td>
-          </tr>
-          <tr>
-            <th>&lt;<a>microphone</a>&gt;</th>
-            <td>[=/"microphone"=]</td>
-          </tr>
-        </tbody>
-      </table>
+      <section>
+        <h4>Algorithms</h4>
 
-      <p>
-        The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
-        &lt;<a>microphone</a>&gt;
-        <dfn data-dfn-for="HTMLUserMediaElement">default constraints</dfn> are:
-      </p>
-      <table class="simple">
-        <thead>
-          <tr>
-            <th>Element type</th>
-            <th>Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th>&lt;<a>usermedia</a>&gt;</th>
-            <td>
-              &laquo;[ {{MediaStreamConstraints/video}} &rarr; true,
-              {{MediaStreamConstraints/audio}} &rarr; true ]&raquo;
-            </td>
-          </tr>
-          <tr>
-            <th>&lt;<a>camera</a>&gt;</th>
-            <td>
-              &laquo;[ {{MediaStreamConstraints/video}} &rarr; true,
-              {{MediaStreamConstraints/audio}} &rarr; false ]&raquo;
-            </td>
-          </tr>
-          <tr>
-            <th>&lt;<a>microphone</a>&gt;</th>
-            <td>
-              &laquo;[ {{MediaStreamConstraints/video}} &rarr; false,
-              {{MediaStreamConstraints/audio}} &rarr; true ]&raquo;
-            </td>
-          </tr>
-        </tbody>
-      </table>
+        <p>
+          The {{HTMLUserMediaElement/constructor()}} steps are:
+        </p>
+        <ol class=algorithm>
+          <li>Initialize {{HTMLUserMediaElement/[[stream]]}} to null.</li>
+          <li>Initialize {{HTMLUserMediaElement/[[error]]}} to null.</li>
+          <li>Initialize {{HTMLUserMediaElement/[[constraints]]}} to [=this=]'s [=HTMLUserMediaElement/default constraints=].</li>
+        </ol>
 
-      <p>
-        The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
-        &lt;<a>microphone</a>&gt; elements' [=EventTarget/activation behavior=],
-        given |element|, is:
-      </p>
-      <ol class=algorithm>
-        <li>
-          If |element|.{{ActivationBlockersMixin/isValid}} is false, then return.
-        </li>
-        <li>
-          If {{HTMLUserMediaElement/[[stream]]}} is null, run
-          [=HTMLUserMediaElement/activation initial=] steps.
-        </li>
-        <li>
-          Otherwise, if |element| is a {{HTMLCameraElement}} or a
-          {{HTMLMicrophoneElement}}, run
-          [=HTMLUserMediaElement/activation second=] steps.
-        </li>
-      </ol>
+        <p>The &lt;<a>usermedia</a>&gt; element's [=insertion steps=], given |element|, are:</p>
+        <ol class=algorithm>
+          <li>
+            If |element| has an {{HTMLUserMediaElement/autostart}} attribute, and {{HTMLUserMediaElement/[[stream]]}} is null,
+            run the [=HTMLUserMediaElement/activation initial=] steps on |element|.
+          </li>
+        </ol>
 
-      <p>The <dfn data-dfn-for="HTMLUserMediaElement">activation initial</dfn> steps are:</p>
-      <ol class=algorithm>
-        <li>[=Assert=]: |element|.{{ActivationBlockersMixin/isValid}}.</li>
-        <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is null.</li>
-        <li>Let |permissionName| be |element|'s [=HTMLUserMediaElement/permission name=].</li>
-        <li>
-          Let |descriptor| be a new {{PermissionDescriptor}} with value
-          &laquo;[ {{PermissionDescriptor/name}} &rarr; |permissionName| ]&raquo;.
-        </li>
-        <li>
-          Let |permissionState| be the result of [=request permission to use=]
-          the [=powerful features=] described by |descriptor| with
-          allowMultiple set to false.
-        </li>
-        <li>If |permissionState| is not {{PermissionState/"granted"}}:
-          <ol>
-            <li>Set {{HTMLUserMediaElement/[[stream]]}} to null.</li>
-            <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
-            <li>Return.</li>
-          </ol>
-        </li>
-        <li>Let |contraints| be {{HTMLUserMediaElement/[[constraints]]}}.</li>
-        <li>
-          Let |mediaPromise| be the result of calling
-          {{MediaDevices/getUserMedia()}} with |constraints| as its first
-          argument.
-        </li>
-        <li>
-          [=promise/React=] to |mediaPromise|:
-          <ol>
-            <li>If |mediaPromise| was fulfilled with value |v|:
-              <ol>
-                <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
-                <li>Set {{HTMLUserMediaElement/[[stream]]}} to |v|.</li>
-                <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
-                <li>Run the [=HTMLUserMediaElement/track monitor=] steps on |element|.</li>
-                <li>[=Fire an event=] named `stream` at |element|.</li>
-              </ol>
-            </li>
-            <li>
-              else:
-              <ol>
-                <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
-                <li>[=Assert=]: |r| is a |DOMException| or an |OverConstrainedError|.</li>
-                <li>Set {{HTMLUserMediaElement/[[stream]]}} to null.</li>
-                <li>Set {{HTMLUserMediaElement/[[error]]}} to |r|.</li>
-                <li>[=Fire an event=] named `stream` at |element|.</li>
-              </ol>
-            </li>
-          </ol>
-        </li>
-      </ol>
+        <p>The {{HTMLUserMediaElement/stream}} <a>getter</a> steps are:</p>
+        <ol class=algorithm>
+          <li>Return {{HTMLUserMediaElement/[[stream]]}}.</li>
+        </ol>
 
-      <p>The <dfn data-dfn-for="HTMLUserMediaElement">activation second</dfn> steps are:</p>
-      <ol class=algorithm>
-        <li>[=Assert=]: |element|.{{ActivationBlockersMixin/isValid}}.</li>
-        <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is a {{MediaStream}}.</li>
-        <li>
-          For each |track| in the result of calling {{MediaStream/getTracks()}}
-          on {{HTMLUserMediaElement/[[stream]]}}:
-          <ol>
-            <li>
-              Set |track|.{{MediaStreamTrack/enabled}} to the negation of
-              |track|.{{MediaStreamTrack/enabled}}.
-            </li>
-          </ol>
-        </li>
-      </ol>
+        <p>
+          The {{HTMLUserMediaElement/setConstraints()}} steps for an |element| and
+          an optional |constraints| parameter are:
+        </p>
+        <ol class=algorithm>
+          <li>
+            Set {{HTMLUserMediaElement/[[constraints]]}} to the result of
+            [=HTMLUserMediaElement/constraint filter=] for |element| and
+            |constraints|.
+          </li>
+        </ol>
 
-      <p>The <dfn data-dfn-for="HTMLUserMediaElement">track monitor</dfn> steps are:</p>
-      <ol class=algorithm>
-        <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is a {{MediaStream}}.</li>
-        <li>
-          For each |track| in the result of calling {{MediaStream/getTracks()}}
-          on {{HTMLUserMediaElement/[[stream]]}}, the user agent MUST monitor
-          the |track|'s {{MediaStreamTrack/readyState}} (specifically for
-          terminations triggered by {{MediaStreamTrack/stop()}}), its
-          {{MediaStreamTrack/enabled}} state, and its
-          {{MediaStreamTrack/muted}} state.
-        </li>
-        <li>
-          When the state of any monitored |track| changes, the user agent MUST update the |element|'s
-          internal UI to reflect the active, muted, or ended state of the |track|, and [=Fire an event=] named `trackchanged` at |element|.
-        </li>
-        <li>
-          If {{HTMLUserMediaElement/[[stream]]}}.{{MediaStream/active}} becomes false, the user agent MUST
-          set {{HTMLUserMediaElement/[[stream]]}} to null and reset the |element|'s
-          internal UI to its initial request state.
-        </li>
-      </ol>
+        <p>The {{HTMLUserMediaElement/error}} <a>getter</a> steps are:</p>
+        <ol class=algorithm>
+          <li>Return {{HTMLUserMediaElement/[[error]]}}.</li>
+        </ol>
 
-      <p>
-        The <dfn data-dfn-for="HTMLUserMediaElement">constraint filter</dfn> steps for an
-        |element| and {{MediaStreamConstraints}} |constraints| are:
-      </p>
-      <ol class=algorithm>
-        <li>Let |result| be a new [=dictionary=].</li>
-        <li>
-          If |element| is a {{HTMLUserMediaElement}}, set |result| to &laquo;[
-            {{MediaStreamConstraints/audio}} &rarr; |constraints| [{{MediaStreamConstraints/audio}}],
-            {{MediaStreamConstraints/video}} &rarr; |constraints| [{{MediaStreamConstraints/video}}]
-          ]&raquo;.
-        </li>
-        <li>
-          Otherwise, if |element| is a {{HTMLMicrophoneElement}}, set |result| to &laquo;[
-            {{MediaStreamConstraints/audio}} &rarr; |constraints| [{{MediaStreamConstraints/audio}}],
-            {{MediaStreamConstraints/video}} &rarr; false
-          ]&raquo;.
-        </li>
-        <li>
-          Otherwise, if |element| is a {{HTMLCameraElement}}, set |result| to &laquo;[
-            {{MediaStreamConstraints/audio}} &rarr; false,
-            {{MediaStreamConstraints/video}} &rarr; |constraints| [{{MediaStreamConstraints/video}}]
-          ]&raquo;.
-        </li>
-        <li>Return |result|.</li>
-      </ol>
+        <p>
+          The &lt;<a>usermedia</a>&gt; <dfn data-dfn-for="HTMLUserMediaElement">permission name</dfn>
+          is: The [=string/concatenate|concatentation=] of &laquo; [=/"camera"=], " ", [=/"microphone"=] &raquo;.
+        </p>
+
+        <p>
+          The &lt;<a>usermedia</a>&gt;
+          <dfn data-dfn-for="HTMLUserMediaElement">default constraints</dfn> are:
+          &laquo;[ "video" &rarr; &laquo;[ ]&raquo;, "audio" &rarr; &laquo;[ ]&raquo; ]&raquo;.
+        </p>
+
+        <p>
+          The &lt;<a>usermedia</a>&gt; element's [=EventTarget/activation behavior=],
+          given |element|, is:
+        </p>
+        <ol class=algorithm>
+          <li>
+            If {{HTMLUserMediaElement/[[stream]]}} is null, run
+            [=HTMLUserMediaElement/activation initial=] steps.
+          </li>
+        </ol>
+
+        <p>The <dfn data-dfn-for="HTMLUserMediaElement">activation initial</dfn> steps are:</p>
+        <ol class=algorithm>
+          <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is null.</li>
+          <li>Let |permissionName| be |element|'s [=HTMLUserMediaElement/permission name=].</li>
+          <li>
+            Let |descriptor| be a new {{PermissionDescriptor}} with value
+            &laquo;[ {{PermissionDescriptor/name}} &rarr; |permissionName| ]&raquo;.
+          </li>
+          <li>
+            Let |permissionState| be the result of [=request permission to use=]
+            the [=powerful features=] described by |descriptor| with
+            allowMultiple set to false.
+          </li>
+          <li>If |permissionState| is not {{PermissionState/"granted"}}:
+            <ol>
+              <li>Set {{HTMLUserMediaElement/[[stream]]}} to null.</li>
+              <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
+              <li>Return.</li>
+            </ol>
+          </li>
+          <li>Let |constraints| be {{HTMLUserMediaElement/[[constraints]]}}.</li>
+          <li>
+            Let |filteredConstraints| be the result of [=HTMLUserMediaElement/constraint filter=] for |element| and |constraints|.
+          </li>
+          <li>
+            Let |mediaPromise| be the result of calling
+            {{MediaDevices/getUserMedia()}} with |filteredConstraints| as its first
+            argument.
+          </li>
+          <li>
+            [=promise/React=] to |mediaPromise|:
+            <ol>
+              <li>If |mediaPromise| was fulfilled with value |v|:
+                <ol>
+                  <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
+                  <li>Set {{HTMLUserMediaElement/[[stream]]}} to |v|.</li>
+                  <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
+                  <li>Run the [=HTMLUserMediaElement/track monitor=] steps on |element|.</li>
+                  <li>[=Fire an event=] named `stream` at |element|.</li>
+                </ol>
+              </li>
+              <li>
+                else:
+                <ol>
+                  <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
+                  <li>[=Assert=]: |r| is a |DOMException|.</li>
+                  <li>Set {{HTMLUserMediaElement/[[stream]]}} to null.</li>
+                  <li>Set {{HTMLUserMediaElement/[[error]]}} to |r|.</li>
+                  <li>[=Fire an event=] named `stream` at |element|.</li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+
+        <p>The <dfn data-dfn-for="HTMLUserMediaElement">track monitor</dfn> steps are:</p>
+        <ol class=algorithm>
+          <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is a {{MediaStream}}.</li>
+          <li>
+            For each |track| in the result of calling {{MediaStream/getTracks()}}
+            on {{HTMLUserMediaElement/[[stream]]}}, the user agent MUST monitor
+            the |track|'s {{MediaStreamTrack/readyState}} (specifically for
+            terminations triggered by {{MediaStreamTrack/stop()}}), its
+            {{MediaStreamTrack/enabled}} state, and its
+            {{MediaStreamTrack/muted}} state.
+          </li>
+          <li>
+            When the state of any monitored |track| changes, the user agent MUST update the |element|'s
+            internal UI to reflect the active, muted, or ended state of the |track|, and [=Fire an event=] named `trackchange` at |element|.
+          </li>
+          <li>
+            If {{HTMLUserMediaElement/[[stream]]}}.{{MediaStream/active}} becomes false, the user agent MUST
+            set {{HTMLUserMediaElement/[[stream]]}} to null and reset the |element|'s
+            internal UI to its initial request state.
+          </li>
+        </ol>
+
+        <p>
+          The <dfn data-dfn-for="HTMLUserMediaElement">constraint filter</dfn> steps for an
+          |element| and an {{HTMLMediaStreamConstraints}} |constraints| are:
+        </p>
+        <ol class=algorithm>
+          <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>
+          <li>If |constraints|["audio"] [=map/exists=], set |result|["audio"] to a copy of |constraints|["audio"]. Otherwise, set |result|["audio"] to an empty [=dictionary=].</li>
+          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["audio"].</li>
+          <li>If |constraints|["video"] [=map/exists=], set |result|["video"] to a copy of |constraints|["video"]. Otherwise, set |result|["video"] to an empty [=dictionary=].</li>
+          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["video"].</li>
+          <li>Return |result|.</li>
+        </ol>
+      </section>
     </section>
   </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -2244,7 +2244,7 @@ onmessage = async ({data: {track}}) => {
 
                 <div class=note>
                 The call to the {{MediaDevices/getUserMedia()}} method should
-                be replaced with anon-IDL entry point or algorithm.</div>
+                be replaced with a non-IDL entry point or algorithm.</div>
               </li>
               <li>
                 [=promise/React=] to |mediaPromise|:
@@ -2510,7 +2510,7 @@ onmessage = async ({data: {track}}) => {
 
                 <div class=note>
                 The call to the {{MediaDevices/getUserMedia()}} method should
-                be replaced with anon-IDL entry point or algorithm.</div>
+                be replaced with a non-IDL entry point or algorithm.</div>
               </li>
               <li>
                 [=promise/React=] to |mediaPromise|:
@@ -2781,7 +2781,7 @@ onmessage = async ({data: {track}}) => {
                 {{HTMLUserMediaElement/[[constraints]]}} as its first argument.
                 <div class=note>
                   The call to the {{MediaDevices/getUserMedia()}} method should
-                  be replaced with anon-IDL entry point or algorithm.
+                  be replaced with a non-IDL entry point or algorithm.
                 </div>
               </li>
               <li>[=promise/React=] to |mediaPromise|:

--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@ partial interface MediaStreamTrack {
         <li><p>If <var>value</var>.`[[IsDetached]]` is <code>true</code>, throw a "DataCloneError" DOMException.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[agentCluster]]` to the [=ECMAScript/surrounding agent=]’s [=ECMAScript/agent cluster=].</p></li>
         <li><p>Set <var>dataHolder</var>.`[[id]]` to <var>value</var>.{{MediaStreamTrack/id}}.</p></li>
-        <li><p>Set <var>dataHolder</var>.`[[kind]]` to <var>value</var>.{{MediaStreamTrack/kind}}.</p></li>
+        <li><p>Set <var>dataHolder</var>.`kind` to <var>value</var>.{{MediaStreamTrack/kind}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[label]]` to <var>value</var>.{{MediaStreamTrack/label}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[readyState]]` to <var>value</var>.{{MediaStreamTrack/readyState}}.</p></li>
         <li><p>Set <var>dataHolder</var>.`[[enabled]]` to <var>value</var>.{{MediaStreamTrack/enabled}}.</p></li>
@@ -412,7 +412,7 @@ partial interface MediaStreamTrack {
         <li><p>If the [=ECMAScript/surrounding agent=]’s [=ECMAScript/agent cluster=] is not
           <var>dataHolder</var>.`[[agentCluster]]`, then throw a "DataCloneError" DOMException.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/id}} to <var>dataHolder</var>.`[[id]]`.</p></li>
-        <li><p>Initialize <var>track</var>.{{MediaStreamTrack/kind}} to <var>dataHolder</var>.`[[kind]]`.</p></li>
+        <li><p>Initialize <var>track</var>.{{MediaStreamTrack/kind}} to <var>dataHolder</var>.`kind`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/label}} to <var>dataHolder</var>.`[[label]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/readyState}} to <var>dataHolder</var>.`[[readyState]]`.</p></li>
         <li><p>Initialize <var>track</var>.{{MediaStreamTrack/enabled}} to <var>dataHolder</var>.`[[enabled]]`.</p></li>
@@ -2153,8 +2153,8 @@ onmessage = async ({data: {track}}) => {
         agent=]. It's expected that the presentation is chiefly that of a button,
         with text and/or an icon to indicate this will give camera access.
         The presentation is expected to reflect the state of the underlying
-        stream (if any), e.g. by hinting to the user that a stream is live
-        (or not), or that the microphone might be open or muted.
+        track (if any), e.g. by hinting to the user that a track is live
+        (or not), or that the camera might be open or muted.
       </p>
 
       <section>
@@ -2192,10 +2192,11 @@ onmessage = async ({data: {track}}) => {
           <li>If [=this=].{{HTMLCameraElement/[[track]]}} is not null, then
             run [=HTMLCameraElement/activation second=] steps.</li>
           <li>Otherwise: If |event| is [=HTMLCameraElement/trusted=], then
-            run [=HTMLCameraElement/activation initial=] steps.</li>
+            run [=HTMLCameraElement/activation initial=] steps given [=this=].</li>
         </ol>
 
-        <p>The <dfn data-dfn-for="HTMLCameraElement">activation initial</dfn> steps are:</p>
+        <p>The <dfn data-dfn-for="HTMLCameraElement">activation initial</dfn>
+        steps for a given |element| are:</p>
         <ol class=algorithm>
           <li>[=Assert=]: [=this=].{{HTMLCameraElement/[[track]]}} is null.</li>
           <li>
@@ -2225,8 +2226,8 @@ onmessage = async ({data: {track}}) => {
                     <ol>
                       <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
                       <li>Let |tracks| be the set of {{MediaStreamTrack}}s in
-                        |v|'s [=/track set=] whose {{MediaStreamTrack/[[Kind]]}}
-                        is equal to "video". (Issue: `[[Kind]]` isn't exported.)</li>
+                        |v|'s [=/track set=] whose {{MediaStreamTrack/kind}}
+                        is equal to "video".</li>
                       <li>Set
                         {{HTMLCameraElement/[[track]]}} to |tracks|[0].</li>
                       <li>Run the [=HTMLCameraElement/track monitor=] steps on [=this=].</li>
@@ -2301,7 +2302,7 @@ onmessage = async ({data: {track}}) => {
           </li>
           <li>
             When the state of the monitored {{HTMLCameraElement/[[track]]}} changes, the user agent MUST update the |element|'s
-            internal UI to reflect the active, muted, or ended state of the track, and [=Fire an event=] named `trackchange` at |element|.
+            internal UI to reflect the active, muted, or ended state of the track.
           </li>
           <li>
             If {{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/readyState}} becomes `"ended"`, the user agent MUST
@@ -2382,11 +2383,10 @@ onmessage = async ({data: {track}}) => {
 
       <p>The &lt;<a>microphone</a>&gt; element's presentation is left to the
         [=user agent=]. It's expected that the presentation is chiefly that of a
-        button, with text and/or an icon to indicate this will give camera
+        button, with text and/or an icon to indicate this will give microphone
         access. The presentation is expected to reflect the state of the
-        underlying stream (if any), e.g. by hinting to the user that a stream
-        is live
-(or not), or that the microphone might be open or muted.
+        underlying track (if any), e.g. by hinting to the user that a track
+        is live (or not), or that the microphone might be open or muted.
       </p>
 
       <section>
@@ -2428,12 +2428,12 @@ onmessage = async ({data: {track}}) => {
           </li>
           <li>
             Otherwise: If |event| is [=HTMLMicrophoneElement/trusted=], then run
-            [=HTMLMicrophoneElement/activation initial=] steps.
+            [=HTMLMicrophoneElement/activation initial=] steps given [=this=].
           </li>
         </ol>
 
         <p>The <dfn data-dfn-for="HTMLMicrophoneElement">activation initial</dfn>
-          steps are:</p>
+          steps for a given |element| are:</p>
 
         <ol class=algorithm>
           <li>[=Assert=]: [=this=].{{HTMLMicrophoneElement/[[track]]}} is null.</li>
@@ -2464,7 +2464,7 @@ onmessage = async ({data: {track}}) => {
                     <ol>
                       <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
                       <li>Let |tracks| be the set of {{MediaStreamTrack}}s in
-                        |v|'s [=/track set=] whose {{MediaStreamTrack/[[Kind]]}}
+                        |v|'s [=/track set=] whose {{MediaStreamTrack/kind}}
                         is equal to "audio".</li>
                       <li>Set
                         {{HTMLMicrophoneElement/[[track]]}} to |tracks|[0].</li>
@@ -2540,7 +2540,7 @@ onmessage = async ({data: {track}}) => {
           </li>
           <li>
             When the state of the monitored {{HTMLMicrophoneElement/[[track]]}} changes, the user agent MUST update the |element|'s
-            internal UI to reflect the active, muted, or ended state of the track, and [=Fire an event=] named `trackchange` at |element|.
+            internal UI to reflect the active, muted, or ended state of the track.
           </li>
           <li>
             If {{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/readyState}} becomes `"ended"`, the user agent MUST
@@ -2626,10 +2626,10 @@ onmessage = async ({data: {track}}) => {
 
       <p>The &lt;<a>usermedia</a>&gt; element's presentation is left to the [=user
         agent=]. It's expected that the presentation is chiefly that of a button,
-        with text and/or an icon to indicate this will give camera access.
-        The presentation is expected to reflect the state of the underlying
+        with text and/or an icon to indicate this will give camera and microphone
+        access. The presentation is expected to reflect the state of the underlying
         stream (if any), e.g. by hinting to the user that a stream is live
-        (or not), or that the microphone might be open or muted.
+        (or not), or that the camera and microphone might be active or muted.
       </p>
 
       <section>
@@ -2668,12 +2668,12 @@ onmessage = async ({data: {track}}) => {
             run [=HTMLUserMediaElement/activation second=] steps.
           </li>
           <li>Otherwise: If |event| is [=HTMLUserMediaElement/trusted=], then
-            run [=HTMLUserMediaElement/activation initial=] steps.
+            run [=HTMLUserMediaElement/activation initial=] steps given [=this=].
           </li>
         </ol>
 
         <p>The <dfn data-dfn-for="HTMLUserMediaElement">activation initial</dfn>
-          steps are:</p>
+          steps for a given |element| are:</p>
         <ol class=algorithm>
           <li>[=Assert=]: [=this=].{{HTMLUserMediaElement/[[stream]]}} is
             null.</li>

--- a/index.html
+++ b/index.html
@@ -2105,7 +2105,7 @@ onmessage = async ({data: {track}}) => {
         <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
       </p>
       <pre class=idl>
-      [Exposed=Window]
+      [Exposed=Window, SecureContext]
       interface HTMLCameraElement : HTMLElement {
         [HTMLConstructor] constructor();
 
@@ -2113,7 +2113,7 @@ onmessage = async ({data: {track}}) => {
         readonly attribute DOMException? error;
         undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
 
-        attribute EventHandler onstream;
+        attribute EventHandler ontrack;
         attribute EventHandler onerror;
         attribute EventHandler oncancel;
       };
@@ -2141,13 +2141,22 @@ onmessage = async ({data: {track}}) => {
         on whether the activation was successful:</p>
 
       <ul>
-        <li><dfn data-dfn-for=HTMLCameraElement>onstream</dfn> &mdash;
-          Activation was successful and a media stream is available.</li>
-        <li><dfn data-dfn-for=HTMLCameraElement>oncancel</dfn> &mdash;
-          Activation was not successful, because the user decided not to proceed.
+        <li><dfn data-dfn-for=HTMLCameraElement>ontrack</dfn>
+          &mdash; [=Event handler IDL attribute=] for the `track`
+          [=event handler=] of [=event handler event type|type=] {{Event}}.
+          It is fired when activation was successful and a media stream is
+          available.</li>
+        <li><dfn data-dfn-for=HTMLCameraElement>oncancel</dfn>
+          &mdash; [=Event handler IDL attribute=] for the `cancel`
+          [=event handler=] of [=event handler event type|type=] {{Event}}.
+          It is fired when activation was not successful because the user
+          decided not to proceed.
           For example, by not accepting a permission prompt.</li>
-        <li><dfn data-dfn-for=HTMLCameraElement>onerror</dfn> &mdash;
-          Activation has failed. No media stream is available. The
+        <li><dfn data-dfn-for=HTMLCameraElement>onerror</dfn>
+          &mdash; [=Event handler IDL attribute=] for the `error`
+          [=event handler=] of [=event handler event type|type=] {{Event}}.
+          It is fired when activation has failed for reasons other than user
+          choice. No media stream is available. The
           {{HTMLCameraElement/error}} attribute holds additional information.</li>
       </ul>
 
@@ -2169,6 +2178,10 @@ onmessage = async ({data: {track}}) => {
           <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">global attributes</a>
         </dt>
         <dd>&mdash; all global content attributes.</dd>
+        <dt>{{HTMLCameraElement/ontrack}}</dt>
+        <dt>{{HTMLCameraElement/oncancel}}</dt>
+        <dt>{{HTMLCameraElement/onerror}}</dt>
+        <dd>&mdash; [=event handler IDL attributes=]</dd>
       </dl>
 
       <p>The &lt;<a>camera</a>&gt; element's presentation is left to the [=user
@@ -2218,93 +2231,93 @@ onmessage = async ({data: {track}}) => {
           given |event| is:
         </p>
         <ol class=algorithm>
-          <li>If [=this=].{{HTMLCameraElement/[[track]]}} is not null, then
-            run [=HTMLCameraElement/activation second=] steps.</li>
-          <li>Otherwise: If |event| is [=HTMLCameraElement/trusted=], then
-            run [=HTMLCameraElement/activation initial=] steps given [=this=].</li>
+          <li>If |event| is not [=HTMLCameraElement/trusted=], then
+            [=fire an event=] named `error`, using an "{{InvalidStateError}}"
+            {{DOMException}}.
+          </li>
+          <li>Otherwise, if {{HTMLCameraElement/[[track]]}} is not null, then run
+            [=HTMLCameraElement/activation start stream=] steps given [=this=].
+          </li>
         </ol>
 
-        <p>The <dfn data-dfn-for="HTMLCameraElement">activation initial</dfn>
+        <div class=note>
+          &lt;<a>camera</a>&gt;'s [=EventTarget/activation behavior=]
+          currently ignores activation when it already has a
+          {{HTMLCameraElement/[[track]]}} set. The intent is that an element
+          with an inactive track will start a new one. And an element with an
+          active track will act as a toggle to allow users to control the
+          stream. The details still need to be determined.
+        </div>
+
+        <p>The <dfn data-dfn-for="HTMLCameraElement">activation start stream</dfn>
         steps for a given |element| are:</p>
         <ol class=algorithm>
           <li>[=Assert=]: [=this=].{{HTMLCameraElement/[[track]]}} is null.</li>
           <li>
-            Let |descriptor| be a new {{PermissionDescriptor}} with value
-            «[ {{PermissionDescriptor/name}} → [=/"camera"=] ]».
+            Let |mediaPromise| be the result of calling
+            [=this=].{{MediaDevices/getUserMedia()}} with {{HTMLCameraElement/[[constraints]]}}
+            as its first argument.
+
+            <div class=note>
+            The call to the {{MediaDevices/getUserMedia()}} method should
+            be replaced with a non-IDL entry point or algorithm.</div>
+            <div class=note>
+              {{MediaDevices/getUserMedia()}} encourages User Agents
+              <q>to bundle concurrent requests for different kinds of media
+                into a single user-facing permission prompt</q>.
+              This applies to here as well. The expected user experience
+              is a single permission prompt that covers the usage of the given
+              element with the given constraints, or even no prompt if the user
+              has already permitted this request before.
+            </div>
           </li>
           <li>
-            Let |permissionState| be the result of [=request permission to use=]
-            the [=powerful features=] described by |descriptor| with
-            allowMultiple set to false.
-          </li>
-          <li>If |permissionState| is {{PermissionState/"granted"}}:
+            [=promise/React=] to |mediaPromise|:
             <ol>
-              <li>
-                Let |mediaPromise| be the result of calling
-                [=this=].{{MediaDevices/getUserMedia()}} with {{HTMLCameraElement/[[constraints]]}}
-                as its first argument.
-
-                <div class=note>
-                The call to the {{MediaDevices/getUserMedia()}} method should
-                be replaced with a non-IDL entry point or algorithm.</div>
-              </li>
-              <li>
-                [=promise/React=] to |mediaPromise|:
+              <li>If |mediaPromise| was fulfilled with value |v|:
                 <ol>
-                  <li>If |mediaPromise| was fulfilled with value |v|:
-                    <ol>
-                      <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
-                      <li>Let |tracks| be the set of {{MediaStreamTrack}}s in
-                        |v|'s [=/track set=] whose {{MediaStreamTrack/kind}}
-                        is equal to "video".</li>
-                      <li>Set
-                        {{HTMLCameraElement/[[track]]}} to |tracks|[0].</li>
-                      <li>Run the [=HTMLCameraElement/track monitor=] steps on [=this=].</li>
-                      <li>[=Fire an event=] named `stream` on [=this=].</li>
+                  <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
+                  <li>Let |tracks| be the set of {{MediaStreamTrack}}s in
+                    |v|'s [=/track set=] whose {{MediaStreamTrack/kind}}
+                    is equal to "video".</li>
+                  <li>[=Assert=]: |tracks|[0] [=set/exists=].</li>
+                  <li>Set
+                    {{HTMLCameraElement/[[track]]}} to |tracks|[0].</li>
+                  <li>Run the [=HTMLCameraElement/track monitor=] steps on [=this=].</li>
+                  <li>[=Fire an event=] named `track` on [=this=].</li>
 
-                    </ol>
-                  </li>
-                  <li>Otherwise:
-                    <ol>
-                      <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
-                      <li>[=Assert=]: |r| is a |DOMException|.</li>
-                      <li>Set [=this=].{{HTMLCameraElement/[[error]]}} to |r|.
-                      <li>[=Fire an event=] named `error` on [=this=],
-                        using {{DOMException}}.
-                        (Description still TBD.)</li>
-                      <li>Return.</li>
-                    </ol>
-                  </li>
+                </ol>
+              </li>
+              <li>Otherwise:
+                <ol>
+                  <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
+                  <li>If |r| indicated that the {{MediaDevices/getUserMedia()}}
+                    call has failed due to user action or inaction, such as a
+                    user rejecting or not answering a permission prompt raised
+                    by {{MediaDevices/getUserMedia()}}, then
+                    [=fire an event=] named `cancel` on [=this=], using
+                    {{DOMException}}, and return.</li>
+                  <li>[=Assert=]: |r| is a |DOMException|.</li>
+                  <li>Set [=this=].{{HTMLCameraElement/[[error]]}} to |r|.
+                  <li>[=Fire an event=] named `error` on [=this=],
+                    using |r|.
+                    (Description still TBD.)</li>
+                  <li>Return.</li>
                 </ol>
               </li>
             </ol>
-          </li>
-          <li>Otherwise, [=fire an event=] named `cancel` on [=this=],
-            using {{DOMException}}.
-            (Description still TBD.)</li>
-        </ol>
-
-        <p>The <dfn data-dfn-for="HTMLCameraElement">activation second</dfn>
-          steps are:</p>
-        <ol class=algorithm>
-          <li>[=Assert=]: [=this=].{{HTMLCameraElement/[[track]]}} is a
-            {{MediaStreamTrack}}.</li>
-          <li>
-            Set [=this=].{{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/enabled}}
-            to the negation of
-            [=this=].{{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/enabled}}.
           </li>
         </ol>
 
         <p>To determine whether an {{Event}} |event| is
           <dfn data-dfn-for=HTMLCameraElement>trusted</dfn>:</p>
 
-        <p class=note>{{HTMLCameraElement}} stream creation is supposed to happen by
+        <div class=note>{{HTMLCameraElement}} stream creation is supposed to happen by
           genuine user action. [=User agents=] SHOULD suppress activation
           for "click-jacking", as well as for programmatic activation. Since
           exact critera for these are difficult to specify, we presently leave
           this as implementation defined. [=User agents=] MUST at minimum
-          reject untrusted events.</p>
+          reject untrusted events.</div>
 
         <ol class=algorithm>
           <li>If |event|.{{Event/isTrusted}} is false: Return false.</li>
@@ -2335,9 +2348,9 @@ onmessage = async ({data: {track}}) => {
             internal UI to reflect the active, muted, or ended state of the track.
           </li>
           <li>
-            If {{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/readyState}} becomes `"ended"`, the user agent MUST
-            set {{HTMLCameraElement/[[track]]}} to null and reset the |element|'s
-            internal UI to its initial request state.
+            If {{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/readyState}}
+            becomes `"ended"`, the user agent MUST update its presentation
+            appropriately.
           </li>
         </ol>
 
@@ -2367,7 +2380,7 @@ onmessage = async ({data: {track}}) => {
         <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
       </p>
       <pre class=idl>
-      [Exposed=Window]
+      [Exposed=Window, SecureContext]
       interface HTMLMicrophoneElement : HTMLElement {
         [HTMLConstructor] constructor();
 
@@ -2375,7 +2388,7 @@ onmessage = async ({data: {track}}) => {
         readonly attribute DOMException? error;
         undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
 
-        attribute EventHandler onstream;
+        attribute EventHandler ontrack;
         attribute EventHandler onerror;
         attribute EventHandler oncancel;
       };
@@ -2402,15 +2415,24 @@ onmessage = async ({data: {track}}) => {
         is expected to fire an event on one of three event handlers, depending
         on whether the activation was successful:</p>
 
-      <ul>
-        <li><dfn data-dfn-for=HTMLMicrophoneElement>onstream</dfn> &mdash;
-          Activation was successful and a media stream is available.</li>
-        <li><dfn data-dfn-for=HTMLMicrophoneElement>oncancel</dfn> &mdash;
-          Activation was not successful, because the user decided not to proceed.
-          For example, by not accepting a permission prompt.</li>
-        <li><dfn data-dfn-for=HTMLMicrophoneElement>onerror</dfn> &mdash;
-          Activation has failed. No media stream is available. The
-          {{HTMLMicrophoneElement/error}} attribute holds additional information.</li>
+     <ul>
+       <li><dfn data-dfn-for=HTMLMicrophoneElement>ontrack</dfn>
+         &mdash; [=Event handler IDL attribute=] for the `track`
+         [=event handler=] of [=event handler event type|type=] {{Event}}.
+         It is fired when activation was successful and a media stream is
+         available.</li>
+       <li><dfn data-dfn-for=HTMLMicrophoneElement>oncancel</dfn>
+         &mdash; [=Event handler IDL attribute=] for the `cancel`
+         [=event handler=] of [=event handler event type|type=] {{Event}}.
+         It is fired when activation was not successful because the user
+         decided not to proceed.
+         For example, by not accepting a permission prompt.</li>
+       <li><dfn data-dfn-for=HTMLMicrophoneElement>onerror</dfn>
+         &mdash; [=Event handler IDL attribute=] for the `error`
+         [=event handler=] of [=event handler event type|type=] {{Event}}.
+         It is fired when activation has failed for reasons other than user
+         choice. No media stream is available. The
+         {{HTMLMicrophoneElement/error}} attribute holds additional information.</li>
       </ul>
 
       <p>
@@ -2431,6 +2453,10 @@ onmessage = async ({data: {track}}) => {
           <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">global attributes</a>
         </dt>
         <dd>&mdash; all global content attributes.</dd>
+        <dt>{{HTMLMicrophoneElement/ontrack}}</dt>
+        <dt>{{HTMLMicrophoneElement/oncancel}}</dt>
+        <dt>{{HTMLMicrophoneElement/onerror}}</dt>
+        <dd>&mdash; [=event handler IDL attributes=]</dd>
       </dl>
 
       <p>The &lt;<a>microphone</a>&gt; element's presentation is left to the
@@ -2479,98 +2505,96 @@ onmessage = async ({data: {track}}) => {
           [=EventTarget/activation behavior=] given |event| is:
         </p>
         <ol class=algorithm>
-          <li>
-            If [=this=].{{HTMLMicrophoneElement/[[track]]}} is not null, then
-            run [=HTMLMicrophoneElement/activation second=] steps.
+          <li>If |event| is not [=HTMLMicrophoneElement/trusted=], then
+            [=fire an event=] named `error`, using an "{{InvalidStateError}}"
+            {{DOMException}}.
           </li>
           <li>
-            Otherwise: If |event| is [=HTMLMicrophoneElement/trusted=], then run
-            [=HTMLMicrophoneElement/activation initial=] steps given [=this=].
+            Otherwise, if {{HTMLMicrophoneElement/[[track]]}} is not null, then
+            run [=HTMLMicrophoneElement/activation start stream=] steps given
+            [=this=].
           </li>
         </ol>
 
-        <p>The <dfn data-dfn-for="HTMLMicrophoneElement">activation initial</dfn>
+        <div class=note>
+          &lt;<a>microphone</a>&gt;'s [=EventTarget/activation behavior=]
+          currently ignores activation when it already has a
+          {{HTMLMicrophoneElement/[[track]]}} set. The intent is that an element
+          with an inactive track will start a new one. And an element with an
+          active track will act as a toggle to allow users to control the
+          stream. The details still need to be determined.
+        </div>
+
+        <p>The
+          <dfn data-dfn-for="HTMLMicrophoneElement">activation start stream</dfn>
           steps for a given |element| are:</p>
 
         <ol class=algorithm>
           <li>[=Assert=]: [=this=].{{HTMLMicrophoneElement/[[track]]}} is null.</li>
           <li>
-            Let |descriptor| be a new {{PermissionDescriptor}} with value
-            «[ {{PermissionDescriptor/name}} → [=/"microphone"=] ]».
+            Let |mediaPromise| be the result of calling
+            [=this=].{{MediaDevices/getUserMedia()}} with
+            {{HTMLMicrophoneElement/[[constraints]]}} as its first argument.
+            <div class=note>
+            The call to the {{MediaDevices/getUserMedia()}} method should
+            be replaced with a non-IDL entry point or algorithm.</div>
+            <div class=note>
+              {{MediaDevices/getUserMedia()}} encourages User Agents
+              <q>to bundle concurrent requests for different kinds of media
+                into a single user-facing permission prompt</q>.
+              This applies to here as well. The expected user experience
+              is a single permission prompt that covers the usage of the given
+              element with the given constraints, or even no prompt if the user
+              has already permitted this request before.
+            </div>
           </li>
           <li>
-            Let |permissionState| be the result of [=request permission to use=]
-            the [=powerful features=] described by |descriptor| with
-            allowMultiple set to false.
-          </li>
-          <li>If |permissionState| is {{PermissionState/"granted"}}:
+            [=promise/React=] to |mediaPromise|:
             <ol>
-              <li>
-                Let |mediaPromise| be the result of calling
-                [=this=].{{MediaDevices/getUserMedia()}} with {{HTMLMicrophoneElement/[[constraints]]}}
-                as its first argument.
-
-                <div class=note>
-                The call to the {{MediaDevices/getUserMedia()}} method should
-                be replaced with a non-IDL entry point or algorithm.</div>
-              </li>
-              <li>
-                [=promise/React=] to |mediaPromise|:
+              <li>If |mediaPromise| was fulfilled with value |v|:
                 <ol>
-                  <li>If |mediaPromise| was fulfilled with value |v|:
-                    <ol>
-                      <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
-                      <li>Let |tracks| be the set of {{MediaStreamTrack}}s in
-                        |v|'s [=/track set=] whose {{MediaStreamTrack/kind}}
-                        is equal to "audio".</li>
-                      <li>Set
-                        {{HTMLMicrophoneElement/[[track]]}} to |tracks|[0].</li>
-                      <li>Run the [=HTMLMicrophoneElement/track monitor=] steps on [=this=].</li>
-                      <li>[=Fire an event=] named `stream` on [=this=].</li>
+                  <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
+                  <li>Let |tracks| be the set of {{MediaStreamTrack}}s in
+                    |v|'s [=/track set=] whose {{MediaStreamTrack/kind}}
+                    is equal to "audio".</li>
+                  <li>[=Assert=]: |tracks|[0] [=set/exists=].</li>
+                  <li>Set
+                    {{HTMLMicrophoneElement/[[track]]}} to |tracks|[0].</li>
+                  <li>Run the [=HTMLMicrophoneElement/track monitor=] steps on [=this=].</li>
+                  <li>[=Fire an event=] named `track` on [=this=].</li>
 
-                    </ol>
-                  </li>
-                  <li>Otherwise:
-                    <ol>
-                      <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
-                      <li>[=Assert=]: |r| is a |DOMException|.</li>
-                      <li>Set {{HTMLMicrophoneElement/[[error]]}} to |r|.
-                      <li>[=Fire an event=] named `error` on [=this=],
-                        using {{DOMException}}.
-                        (Description still TBD.)</li>
-                      <li>Return.</li>
-                    </ol>
-                  </li>
+                </ol>
+              </li>
+              <li>Otherwise:
+                <ol>
+                  <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
+                  <li>If |r| indicated that the {{MediaDevices/getUserMedia()}}
+                    call has failed due to user action or inaction, such as a
+                    user rejecting or not answering a permission prompt raised
+                    by {{MediaDevices/getUserMedia()}}, then
+                    [=fire an event=] named `cancel` on [=this=], using
+                    {{DOMException}}, and return.</li>
+                  <li>[=Assert=]: |r| is a |DOMException|.</li>
+                  <li>Set {{HTMLMicrophoneElement/[[error]]}} to |r|.
+                  <li>[=Fire an event=] named `error` on [=this=],
+                    using |r|.
+                    (Description still TBD.)</li>
+                  <li>Return.</li>
                 </ol>
               </li>
             </ol>
-          </li>
-          <li>Otherwise, [=fire an event=] named `cancel` on [=this=],
-            using {{DOMException}}.
-            (Description still TBD.)</li>
-        </ol>
-
-        <p>The <dfn data-dfn-for="HTMLMicrophoneElement">activation second</dfn>
-          steps are:</p>
-        <ol class=algorithm>
-          <li>[=Assert=]: [=this=].{{HTMLMicrophoneElement/[[track]]}} is a
-            {{MediaStreamTrack}}.</li>
-          <li>
-            Set [=this=].{{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/enabled}}
-            to the negation of
-            [=this=].{{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/enabled}}.
           </li>
         </ol>
 
         <p>To determine whether an {{Event}} |event| is
           <dfn data-dfn-for=HTMLMicrophoneElement>trusted</dfn>:</p>
 
-        <p class=note>{{HTMLMicrophoneElement}} stream creation is supposed to happen by
+        <div class=note>{{HTMLMicrophoneElement}} stream creation is supposed to happen by
           genuine user action. [=User agents=] SHOULD suppress activation
           for "click-jacking", as well as for programmatic activation. Since
           exact critera for these are difficult to specify, we presently leave
           this as implementation defined. [=User agents=] MUST at minimum
-          reject untrusted events.</p>
+          reject untrusted events.</div>
 
         <ol class=algorithm>
           <li>If |event|.{{Event/isTrusted}} is false: Return false.</li>
@@ -2601,9 +2625,9 @@ onmessage = async ({data: {track}}) => {
             internal UI to reflect the active, muted, or ended state of the track.
           </li>
           <li>
-            If {{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/readyState}} becomes `"ended"`, the user agent MUST
-            set {{HTMLMicrophoneElement/[[track]]}} to null and reset the |element|'s
-            internal UI to its initial request state.
+            If {{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/readyState}}
+            becomes `"ended"`, the user agent MUST update its presentation
+            appropriately.
           </li>
         </ol>
 
@@ -2633,12 +2657,13 @@ onmessage = async ({data: {track}}) => {
         <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
       </p>
       <pre class=idl>
+      [SecureContext]
       dictionary HTMLMediaStreamConstraints {
         MediaTrackConstraintSet video;
         MediaTrackConstraintSet audio;
       };
 
-      [Exposed=Window]
+      [Exposed=Window, SecureContext]
       interface HTMLUserMediaElement : HTMLElement {
         [HTMLConstructor] constructor();
 
@@ -2668,19 +2693,28 @@ onmessage = async ({data: {track}}) => {
         </li>
       </ul>
 
-     <p>The &lt;<a>usermedia</a>&gt; element's activation is filtered to allow
-        only activitations that result from genuine user action. Each activation
-        is expected to fire an event on one of three event handlers, depending
-        on whether the activation was successful:</p>
+      <p>The &lt;<a>usermedia</a>&gt; element's activation is filtered to allow
+         only activitations that result from genuine user action. Each activation
+         is expected to fire an event on one of three event handlers, depending
+         on whether the activation was successful:</p>
 
       <ul>
-        <li><dfn data-dfn-for=HTMLUserMediaElement>onstream</dfn> &mdash;
-          Activation was successful and a media stream is available.</li>
-        <li><dfn data-dfn-for=HTMLUserMediaElement>oncancel</dfn> &mdash;
-          Activation was not successful, because the user decided not to proceed.
+        <li><dfn data-dfn-for=HTMLUserMediaElement>onstream</dfn>
+          &mdash; [=Event handler IDL attribute=] for the `stream`
+          [=event handler=] of [=event handler event type|type=] {{Event}}.
+          It is fired when activation was successful and a media stream is
+          available.</li>
+        <li><dfn data-dfn-for=HTMLUserMediaElement>oncancel</dfn>
+          &mdash; [=Event handler IDL attribute=] for the `cancel`
+          [=event handler=] of [=event handler event type|type=] {{Event}}.
+          It is fired when activation was not successful because the user
+          decided not to proceed.
           For example, by not accepting a permission prompt.</li>
-        <li><dfn data-dfn-for=HTMLUserMediaElement>onerror</dfn> &mdash;
-          Activation has failed. No media stream is available. The
+        <li><dfn data-dfn-for=HTMLUserMediaElement>onerror</dfn>
+          &mdash; [=Event handler IDL attribute=] for the `error`
+          [=event handler=] of [=event handler event type|type=] {{Event}}.
+          It is fired when activation has failed for reasons other than user
+          choice. No media stream is available. The
           {{HTMLUserMediaElement/error}} attribute holds additional information.</li>
       </ul>
 
@@ -2702,6 +2736,10 @@ onmessage = async ({data: {track}}) => {
           <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">global attributes</a>
         </dt>
         <dd>&mdash; all global content attributes.</dd>
+        <dt>{{HTMLUserMediaElement/onstream}}</dt>
+        <dt>{{HTMLUserMediaElement/oncancel}}</dt>
+        <dt>{{HTMLUserMediaElement/onerror}}</dt>
+        <dd>&mdash; [=event handler IDL attributes=]</dd>
       </dl>
 
       <p>The &lt;<a>usermedia</a>&gt; element's presentation is left to the [=user
@@ -2751,92 +2789,77 @@ onmessage = async ({data: {track}}) => {
           given |event|, is:
         </p>
         <ol class=algorithm>
-          <li>If [=this=].{{HTMLUserMediaElement/[[stream]]}} is not null, then
-            run [=HTMLUserMediaElement/activation second=] steps.
+          <li>If |event| is not [=HTMLUserMediaElement/trusted=], then
+            [=fire an event=] named `error`, using an "{{InvalidStateError}}"
+            {{DOMException}}.
           </li>
-          <li>Otherwise: If |event| is [=HTMLUserMediaElement/trusted=], then
-            run [=HTMLUserMediaElement/activation initial=] steps given [=this=].
+          <li>
+            Otherwise, if {{HTMLUserMediaElement/[[stream]]}} is not null, then
+            run [=HTMLUserMediaElement/activation start stream=] steps given
+            [=this=].
           </li>
         </ol>
 
-        <p>The <dfn data-dfn-for="HTMLUserMediaElement">activation initial</dfn>
+        <div class=note>
+          &lt;<a>usermedia</a>&gt;'s [=EventTarget/activation behavior=]
+          currently ignores activation when it already has a
+          {{HTMLUserMediaElement/[[stream]]}} set. The intent is that an element
+          with an inactive stream will start a new one. And an element with an
+          active stream will act as a toggle to allow users to control the
+          stream. The details still need to be determined.
+        </div>
+
+
+        <p>The <dfn data-dfn-for="HTMLUserMediaElement">activation start stream</dfn>
           steps for a given |element| are:</p>
         <ol class=algorithm>
           <li>[=Assert=]: [=this=].{{HTMLUserMediaElement/[[stream]]}} is
             null.</li>
-          <li>Let |permissionName| be the [=string/concatenate|concatentation=]
-            of &laquo; [=/"camera"=], " ", [=/"microphone"=] &raquo;.
-          <li>
-            Let |descriptor| be a new {{PermissionDescriptor}} with value
-            &laquo;[ {{PermissionDescriptor/name}} &rarr; |permissionName|
-            ]&raquo;.
+          <li>Let |mediaPromise| be the result of calling
+            [=this=].{{MediaDevices/getUserMedia()}} with
+            {{HTMLUserMediaElement/[[constraints]]}} as its first argument.
+            <div class=note>
+              The call to the {{MediaDevices/getUserMedia()}} method should
+              be replaced with a non-IDL entry point or algorithm.
+            </div>
+            <div class=note>
+              {{MediaDevices/getUserMedia()}} encourages User Agents
+              <q>to bundle concurrent requests for different kinds of media
+                into a single user-facing permission prompt</q>.
+              This applies here as well. The expected user experience
+              is a single permission prompt that covers the usage of the given
+              element with the given constraints, or even no prompt if the user
+              has already permitted this request before.
+            </div>
           </li>
-          <li>
-            Let |permissionState| be the result of [=request permission to use=]
-            the [=powerful features=] described by |descriptor| with
-            allowMultiple set to false.
-          </li>
-          <li>If |permissionState| is {{PermissionState/"granted"}}:
+          <li>[=promise/React=] to |mediaPromise|:
             <ol>
-              <li>Let |mediaPromise| be the result of calling
-                [=this=].{{MediaDevices/getUserMedia()}} with
-                {{HTMLUserMediaElement/[[constraints]]}} as its first argument.
-                <div class=note>
-                  The call to the {{MediaDevices/getUserMedia()}} method should
-                  be replaced with a non-IDL entry point or algorithm.
-                </div>
-              </li>
-              <li>[=promise/React=] to |mediaPromise|:
+              <li>If |mediaPromise| was fulfilled with value |v|:
                 <ol>
-                  <li>If |mediaPromise| was fulfilled with value |v|:
-                    <ol>
-                      <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
-                      <li>Set {{HTMLUserMediaElement/[[stream]]}} to |v|.</li>
-                      <li>Run the [=HTMLUserMediaElement/track monitor=]
-                        steps on [=this=].</li>
-                      <li>[=Fire an event=] named `stream` on [=this=].</li>
-                    </ol>
-                  </li>
-                  <li>
-                    Otherwise:
-                    <ol>
-                      <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
-                      <li>[=Assert=]: |r| is a |DOMException|.</li>
-                      <li>Set {{HTMLUserMediaElement/[[error]]}} to |r|.
-                      <li>[=Fire an event=] named `error` on [=this=],
-                        using {{DOMException}}. (Description still TBD.).</li>
-                      <li>Return.</li>
-                    </ol>
-                  </li>
+                  <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
+                  <li>Set {{HTMLUserMediaElement/[[stream]]}} to |v|.</li>
+                  <li>Run the [=HTMLUserMediaElement/track monitor=]
+                    steps on [=this=].</li>
+                  <li>[=Fire an event=] named `stream` on [=this=].</li>
                 </ol>
               </li>
-            </ol>
-          </li>
-          <li>[=Fire an event=] named `cancel` on [=this=],
-             using {{DOMException}}. (Description still TBD.).
-          </li>
-        </ol>
-
-        <p>
-          The &lt;<a>usermedia</a>&gt; element's
-          <dfn data-dfn-for="HTMLUserMediaElement">activation second</dfn> steps are:
-        </p>
-        <ol class=algorithm>
-          <li>[=Assert=]: [=this=].{{HTMLUserMediaElement/[[stream]]}} is a
-            {{MediaStream}}.</li>
-          <li>Let |enabled| be true.</li>
-          <li>
-            [=list/iterate|For each=] |track| of
-            {{HTMLUserMediaElement/[[stream]]}}'s [=/track set=]:
-            <ol>
-              <li>If |track|.{{MediaStreamTrack/enabled}} is false, set |enabled| to false.</li>
-            </ol>
-          </li>
-          <li>
-            [=list/iterate|For each=] |track| of
-            {{HTMLUserMediaElement/[[stream]]}}'s [=/track set=]:
-            <ol>
-              <li>Set |track|.{{MediaStreamTrack/enabled}} to the negation of |enabled|.</li>
+              <li>
+                Otherwise:
+                <ol>
+                  <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
+                  <li>If |r| indicated that the {{MediaDevices/getUserMedia()}}
+                    call has failed due to user action or inaction, such as a
+                    user rejecting or not answering a permission prompt raised
+                    by {{MediaDevices/getUserMedia()}}, then
+                    [=fire an event=] named `cancel` on [=this=], using
+                    {{DOMException}}, and return.</li>
+                  <li>[=Assert=]: |r| is a |DOMException|.</li>
+                  <li>Set {{HTMLUserMediaElement/[[error]]}} to |r|.
+                  <li>[=Fire an event=] named `error` on [=this=],
+                    using {{DOMException}}. (Description still TBD.).</li>
+                  <li>Return.</li>
+                </ol>
+              </li>
             </ol>
           </li>
         </ol>
@@ -2844,12 +2867,12 @@ onmessage = async ({data: {track}}) => {
         <p>To determine whether an {{Event}} |event| is
           <dfn data-dfn-for=HTMLUserMediaElement>trusted</dfn>:</p>
 
-        <p class=note>{{HTMLUserMediaElement}} stream creation is supposed to happen by
+        <div class=note>{{HTMLUserMediaElement}} stream creation is supposed to happen by
           genuine user action. [=User agents=] SHOULD suppress activation
           for "click-jacking", as well as for programmatic activation. Since
           exact critera for these are difficult to specify, we presently leave
           this as implementation defined. [=User agents=] MUST at minimum
-          reject untrusted events.</p>
+          reject untrusted events.</div>
 
         <ol class=algorithm>
           <li>If |event|.{{Event/isTrusted}} is false: Return false.</li>
@@ -2874,8 +2897,8 @@ onmessage = async ({data: {track}}) => {
             internal UI to reflect the active, muted, or ended state of the |track|.
           </li>
           <li>
-            If {{HTMLUserMediaElement/[[stream]]}}.{{MediaStream/active}} becomes false, the user agent MUST
-            set {{HTMLUserMediaElement/[[stream]]}} to null and reset the |element|'s
+            If {{HTMLUserMediaElement/[[stream]]}}.{{MediaStream/active}}
+            becomes `"ended"`, the user agent MUST reset the |element|'s
             internal UI to its initial request state.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -1736,6 +1736,7 @@ partial dictionary MediaTrackConstraintSet {
           <dd>See <a href=
             "#def-constraint-humanFaceDetectionMode">
             humanFaceDetectionMode</a> for details.</dd>
+          </dd>
         </dl>
       </section>
     </section>
@@ -1752,6 +1753,7 @@ partial dictionary MediaTrackSettings {
           <dd>See <a href=
             "#def-constraint-humanFaceDetectionMode">
             humanFaceDetectionMode</a> for details.</dd>
+          </dd>
         </dl>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
   var respecConfig = {
     group: "webrtc",
-    xref: ["geometry-1", "html", "infra", "permissions", "dom", "hr-time", "image-capture", "mediacapture-streams", "screen-capture", "webaudio", "webcodecs", "webidl", "ECMAScript", "geolocation-element"],
+    xref: ["geometry-1", "html", "infra", "permissions", "dom", "hr-time", "image-capture", "mediacapture-streams", "screen-capture", "webaudio", "webcodecs", "webidl", "ECMAScript"],
     edDraftURI: "https://w3c.github.io/mediacapture-extensions/",
     editors:  [
       {name: "Jan-Ivar Bruaroey", company: "Mozilla Corporation", w3cid: 79152},
@@ -1233,7 +1233,7 @@ partial dictionary VideoFrameMetadata {
       When the <dfn class="abstract-op">Initialize Video Frame Timestamps From Internal MediaStreamTrack Video Frame</dfn>
       algorithm is invoked with |frame| and |offset| as input, run the following steps.
       <ol class=algorithm>
-          <li>Set {{VideoFrame/timestamp}} from [=presentation timestamp=] minus |offset|.</li>
+        <li>Set {{VideoFrame/timestamp}} from [=presentation timestamp=] minus |offset|.</li>
         <li>Set {{VideoFrameMetadata/captureTime}} from [=capture timestamp=] if set.</li>
         <li>Set {{VideoFrameMetadata/receiveTime}} from [=receive timestamp=] if set.</li>
         <li>Set {{VideoFrameMetadata/rtpTimestamp}} from [=RTP timestamp=] if set.</li>
@@ -1241,7 +1241,7 @@ partial dictionary VideoFrameMetadata {
       When the <dfn class="abstract-op">Copy Video Frame Timestamps To Internal MediaStreamTrack Video Frame</dfn>
       algorithm runs with |frame| as input, run the following steps.
       <ol class=algorithm>
-          <li>Set [=presentation timestamp=] from {{VideoFrame/timestamp}}.</li>
+        <li>Set [=presentation timestamp=] from {{VideoFrame/timestamp}}.</li>
         <li>Set [=capture timestamp=] from {{VideoFrameMetadata/captureTime}} if [=map/exist|present=].</li>
         <li>Set [=receive timestamp=] from {{VideoFrameMetadata/receiveTime}} if [=map/exist|present=].</li>
         <li>Set [=RTP timestamp=] from {{VideoFrameMetadata/rtpTimestamp}} if [=map/exist|present=].</li>
@@ -1469,7 +1469,7 @@ partial dictionary MediaTrackCapabilities {
 };
         </pre>
         </p>
-      <h3>Processing considerations</h3>
+      <h4>Processing considerations</h4>
       <p>
         When the "voiceIsolation" setting is set to <code>true</code> by the
         <a>ApplyConstraints algorithm</a>, the UA
@@ -2088,9 +2088,8 @@ onmessage = async ({data: {track}}) => {
   <section>
     <h2>Media capture HTML elements</h2>
     <p>
-      The following are [[HTML]] elements that let the user turn on camera and/or microphone, including handling the required [=permission/prompts=] for [=powerful features=].
-    </p>
-    <p>
+      The following are [[HTML]] elements that let the user initiate media
+      capture, i.e. turn on camera and/or microphone.
       They cover different use cases and allow for use case specific user interfaces in the [=user agent=].
     </p>
 
@@ -2112,14 +2111,10 @@ onmessage = async ({data: {track}}) => {
 
         readonly attribute MediaStreamTrack? track;
         undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
-        readonly attribute any error;
-
-        attribute boolean autostart;
 
         attribute EventHandler onstream;
-        attribute EventHandler ontrackchange;
+        attribute EventHandler onerror;
       };
-      HTMLCameraElement includes PowerfulFeatureObserver;
       </pre>
 
       <p>The &lt;<a>camera</a>&gt; element uses the following internal slots:</p>
@@ -2131,10 +2126,6 @@ onmessage = async ({data: {track}}) => {
         <li>
           <dfn data-dfn-for="HTMLCameraElement">[[\constraints]]</dfn> &mdash;
           Holds a {{MediaTrackConstraintSet}}.
-        </li>
-        <li>
-          <dfn data-dfn-for="HTMLCameraElement">[[\error]]</dfn> &mdash;
-          Holds a {{DOMException}} or null.
         </li>
       </ul>
 
@@ -2156,149 +2147,145 @@ onmessage = async ({data: {track}}) => {
           <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">global attributes</a>
         </dt>
         <dd>&mdash; all global content attributes.</dd>
-        <dt>
-          <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-powerfulfeatureobserver-attributes">PowerfulFeatureObserver attributes</a>
-        </dt>
-        <dd>&mdash; attributes provided by the PowerfulFeatureObserver mixin.</dd>
-        <dt>
-          <dfn data-dfn-for="HTMLCameraElement">autostart</dfn>
-        </dt>
-        <dd>&mdash; A boolean attribute indicating whether to try to start the stream automatically as the element is added to the DOM and rendered.</dd>
-
       </dl>
+
+      <p>The &lt;<a>camera</a>&gt; element's presentation is left to the [=user
+        agent=]. It's expected that the presentation is chiefly that of a button,
+        with text and/or an icon to indicate this will give camera access.
+        The presentation is expected to reflect the state of the underlying
+        stream (if any), e.g. by hinting to the user that a stream is live
+        (or not), or that the microphone might be open or muted.
+      </p>
 
       <section>
         <h4>Algorithms</h4>
 
         <p>
-          The {{HTMLCameraElement/constructor()}} steps are:
+        The <dfn data-dfn-for=HTMLCameraElement>constructor()</dfn> steps are:
         </p>
         <ol class=algorithm>
-          <li>Initialize {{HTMLCameraElement/[[track]]}} to null.</li>
-          <li>Initialize {{HTMLCameraElement/[[error]]}} to null.</li>
-          <li>Initialize {{HTMLCameraElement/[[constraints]]}} to [=this=]'s [=HTMLCameraElement/default constraints=].</li>
-          <li>Initialize {{PowerfulFeatureObserver/[[Features]]}} to &laquo; "camera" &raquo;.</li>
-          <li>Run <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver">PowerfulFeatureObserver</a>'s <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-initialization-steps">initialization steps</a>.</li>
+          <li>Initialize [=this=].{{HTMLCameraElement/[[track]]}} to null.</li>
+          <li>Initialize [=this=].{{HTMLCameraElement/[[constraints]]}} to «».</li>
         </ol>
 
-        <p>The &lt;<a>camera</a>&gt; element's [=insertion steps=], given |element|, are:</p>
+        <p>The <dfn data-dfn-for=HTMLCameraElement>track</dfn> <a>getter</a> steps are:</p>
         <ol class=algorithm>
-          <li>
-            If |element| has an {{HTMLCameraElement/autostart}} attribute, and {{HTMLCameraElement/[[track]]}} is null,
-            run the [=HTMLCameraElement/activation initial=] steps on |element|.
-          </li>
-        </ol>
-
-        <p>The {{HTMLCameraElement/track}} <a>getter</a> steps are:</p>
-        <ol class=algorithm>
-          <li>Return {{HTMLCameraElement/[[track]]}}.</li>
+          <li>Return [=this=].{{HTMLCameraElement/[[track]]}}.</li>
         </ol>
 
         <p>
-          The {{HTMLCameraElement/setConstraints()}} steps for an |element| and
-          an optional |constraints| parameter are:
+        The <dfn data-dfn-for=HTMLCameraElement>setConstraints()</dfn> steps with
+        a parameter |constraints| are:
         </p>
         <ol class=algorithm>
           <li>
-            Set {{HTMLCameraElement/[[constraints]]}} to the result of
-            [=HTMLCameraElement/constraint filter=] for |element| and
-            |constraints|.
+            Set [=this=].{{HTMLCameraElement/[[constraints]]}} to the result of
+            [=HTMLCameraElement/constraint filter=] for |constraints|.
           </li>
         </ol>
 
-        <p>The {{HTMLCameraElement/error}} <a>getter</a> steps are:</p>
-        <ol class=algorithm>
-          <li>Return {{HTMLCameraElement/[[error]]}}.</li>
-        </ol>
-
         <p>
-          The &lt;<a>camera</a>&gt; <dfn data-dfn-for="HTMLCameraElement">permission name</dfn>
-          is: [=/"camera"=].
-        </p>
-
-        <p>
-          The &lt;<a>camera</a>&gt;
-          <dfn data-dfn-for="HTMLCameraElement">default constraints</dfn> are:
-          &laquo;[ ]&raquo;.
-        </p>
-
-        <p>
-          The &lt;<a>camera</a>&gt; element's [=EventTarget/activation behavior=],
-          given |element|, is:
+          The &lt;<a>camera</a>&gt; element's [=EventTarget/activation behavior=]
+          given |event| is:
         </p>
         <ol class=algorithm>
-          <li>
-            If {{HTMLCameraElement/[[track]]}} is null, run
-            [=HTMLCameraElement/activation initial=] steps.
-          </li>
-          <li>
-            Otherwise, run [=HTMLCameraElement/activation second=] steps.
-          </li>
+          <li>If [=this=].{{HTMLCameraElement/[[track]]}} is not null, then
+            run [=HTMLCameraElement/activation second=] steps.</li>
+          <li>Otherwise: If |event| is [=HTMLCameraElement/trusted=], then
+            run [=HTMLCameraElement/activation initial=] steps.</li>
         </ol>
 
         <p>The <dfn data-dfn-for="HTMLCameraElement">activation initial</dfn> steps are:</p>
         <ol class=algorithm>
-          <li>[=Assert=]: {{HTMLCameraElement/[[track]]}} is null.</li>
-          <li>Let |permissionName| be |element|'s [=HTMLCameraElement/permission name=].</li>
+          <li>[=Assert=]: [=this=].{{HTMLCameraElement/[[track]]}} is null.</li>
           <li>
             Let |descriptor| be a new {{PermissionDescriptor}} with value
-            &laquo;[ {{PermissionDescriptor/name}} &rarr; |permissionName| ]&raquo;.
+            «[ {{PermissionDescriptor/name}} → [=/"camera"=] ]».
           </li>
           <li>
             Let |permissionState| be the result of [=request permission to use=]
             the [=powerful features=] described by |descriptor| with
             allowMultiple set to false.
           </li>
-          <li>If |permissionState| is not {{PermissionState/"granted"}}:
+          <li>If |permissionState| is {{PermissionState/"granted"}}:
             <ol>
-              <li>Set {{HTMLCameraElement/[[track]]}} to null.</li>
-              <li>Set {{HTMLCameraElement/[[error]]}} to null.</li>
-              <li>Return.</li>
-            </ol>
-          </li>
-          <li>Let |constraints| be {{HTMLCameraElement/[[constraints]]}}.</li>
-          <li>
-            Let |filteredConstraints| be the result of [=HTMLCameraElement/constraint filter=] for |element| and |constraints|.
-          </li>
-          <li>
-            Let |mediaPromise| be the result of calling
-            {{MediaDevices/getUserMedia()}} with |filteredConstraints| as its first
-            argument.
-          </li>
-          <li>
-            [=promise/React=] to |mediaPromise|:
-            <ol>
-              <li>If |mediaPromise| was fulfilled with value |v|:
-                <ol>
-                  <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
-                  <li>Let |tracks| be the result of calling {{MediaStream/getVideoTracks()}} on |v|.</li>
-                  <li>If |tracks| is empty, set {{HTMLCameraElement/[[track]]}} to null. Otherwise, set {{HTMLCameraElement/[[track]]}} to |tracks|[0].</li>
-                  <li>Set {{HTMLCameraElement/[[error]]}} to null.</li>
-                  <li>Run the [=HTMLCameraElement/track monitor=] steps on |element|.</li>
-                  <li>[=Fire an event=] named `stream` at |element|.</li>
-                </ol>
+              <li>
+                Let |mediaPromise| be the result of calling
+                [=this=].{{MediaDevices/getUserMedia()}} with {{HTMLCameraElement/[[constraints]]}}
+                as its first argument.
+
+                <div class=note>
+                The call to the {{MediaDevices/getUserMedia()}} method should
+                be replaced with anon-IDL entry point or algorithm.</div>
               </li>
               <li>
-                else:
+                [=promise/React=] to |mediaPromise|:
                 <ol>
-                  <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
-                  <li>[=Assert=]: |r| is a |DOMException|.</li>
-                  <li>Set {{HTMLCameraElement/[[track]]}} to null.</li>
-                  <li>Set {{HTMLCameraElement/[[error]]}} to |r|.</li>
-                  <li>[=Fire an event=] named `stream` at |element|.</li>
+                  <li>If |mediaPromise| was fulfilled with value |v|:
+                    <ol>
+                      <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
+                      <li>Let |tracks| be the result of calling {{MediaStream/getVideoTracks()}} on |v|.</li>
+                      <li>If |tracks| is not empty, set
+                        {{HTMLCameraElement/[[track]]}} to |tracks|[0].</li>
+                      <li>If {{HTMLCameraElement/[[track]]}} is null:
+                        <ol>
+                          <li>[=Fire an event=] named `error` on [=this=],
+                            using {{DOMException}}.
+                            (Description still TBD.)</li>
+                          <li>Return.</li>
+                        </ol>
+                      </li>
+                      <li>Run the [=HTMLCameraElement/track monitor=] steps on [=this=].</li>
+                      <li>[=Fire an event=] named `stream` on [=this=].</li>
+
+                    </ol>
+                  </li>
+                  <li>Otherwise:</li>
+                    <ol>
+                      <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
+                      <li>[=Assert=]: |r| is a |DOMException|.</li>
+                      <li>[=Fire an event=] named `error` on [=this=],
+                        using {{DOMException}}.
+                        (Description still TBD.)</li>
+                      <li>Return.</li>
+                    </ol>
+                  </li>
                 </ol>
               </li>
             </ol>
+          </li>
+          <li>Otherwise, [=fire an event=] named `error` on [=this=],
+            using {{DOMException}}.
+            (Description still TBD.)</li>
+        </ol>
+
+        <p>The <dfn data-dfn-for="HTMLCameraElement">activation second</dfn>
+          steps are:</p>
+        <ol class=algorithm>
+          <li>[=Assert=]: [=this=].{{HTMLCameraElement/[[track]]}} is a
+            {{MediaStreamTrack}}.</li>
+          <li>
+            Set [=this=].{{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/enabled}}
+            to the negation of
+            [=this=].{{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/enabled}}.
           </li>
         </ol>
 
-        <p>The <dfn data-dfn-for="HTMLCameraElement">activation second</dfn> steps are:</p>
+        <p>To determine wheter an {{Event}} |event| is
+          <dfn data-dfn-for=HTMLCameraElement>trusted</dfn>:</p>
+
+        <p class=note>{{HTMLCameraElement}} stream creation is supposed to happen by
+          genuine user action. [=User agents=] SHOULD suppress activation
+          for "click-jacking", as well as for programmatic activation. Since
+          exact critera for these are difficult to specify, we presently leave
+          this as implementation defined. [=User agents=] MUST at minimum
+          reject untrusted events.</p>
+
         <ol class=algorithm>
-          <li>[=Assert=]: {{HTMLCameraElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
-          <li>
-            Set {{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/enabled}} to the negation of
-            {{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/enabled}}.
-          </li>
+          <li>If |event|.{{Event/isTrusted}} is false: Return false.</li>
+          <li>[=User agents=] SHOULD run additional, implementation-defined steps
+            to determine trusted-ness of |event|.</li>
+          <li>Return true.</li>
         </ol>
 
         <p>The <dfn data-dfn-for="HTMLCameraElement">track monitor</dfn> steps are:</p>
@@ -2306,10 +2293,17 @@ onmessage = async ({data: {track}}) => {
           <li>[=Assert=]: {{HTMLCameraElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
           <li>
             The user agent MUST monitor the {{HTMLCameraElement/[[track]]}}'s
-            {{MediaStreamTrack/readyState}} (specifically for
+            {{MediaStreamTrack/readyState}} (including for
             terminations triggered by {{MediaStreamTrack/stop()}}), its
             {{MediaStreamTrack/enabled}} state, and its
             {{MediaStreamTrack/muted}} state.
+            <div class=note>This monitoring is mostly provided by existing
+              event handlers on {{MediaStreamTrack}}, except that the
+              {{MediaStreamTrack/stop()}} method
+              <a href="https://w3c.github.io/mediacapture-main/#ends-nostop">will not dispatch any events</a>.
+              However, a track ending due to {{MediaStreamTrack/stop()}}
+              should still reflect the {{HTMLCameraElement}} state.
+            </div>
           </li>
           <li>
             When the state of the monitored {{HTMLCameraElement/[[track]]}} changes, the user agent MUST update the |element|'s
@@ -2323,8 +2317,8 @@ onmessage = async ({data: {track}}) => {
         </ol>
 
         <p>
-          The <dfn data-dfn-for="HTMLCameraElement">constraint filter</dfn> steps for an
-          |element| and a {{MediaTrackConstraintSet}} |constraints| are:
+          The <dfn data-dfn-for="HTMLCameraElement">constraint filter</dfn> steps
+          for a {{MediaTrackConstraintSet}} |constraints| are:
         </p>
         <ol class=algorithm>
           <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>

--- a/index.html
+++ b/index.html
@@ -2240,10 +2240,9 @@ onmessage = async ({data: {track}}) => {
             <div class=note>
               [^camera^]'s [=EventTarget/activation behavior=]
               currently ignores activation when it already has a
-              {{HTMLCameraElement/[[track]]}} set. The intent is that an element
-              with an ended track will start a new one. The behaviour for
-              an element with an active track still need to be determined.
-            </div>
+              {{HTMLCameraElement/[[track]]}} set. The behaviour for
+              an element with a track still needs to be determined.
+           </div>
           </li>
           <li>Run [=HTMLCameraElement/activation start stream=] steps given
             [=this=].
@@ -2290,7 +2289,7 @@ onmessage = async ({data: {track}}) => {
                   <li>Set
                     {{HTMLCameraElement/[[track]]}} to |tracks|[0].</li>
                   <li>Run the [=HTMLCameraElement/track monitor=] steps on [=this=].</li>
-                  <li>[=Fire an event=] named `track` on [=this=].</li>
+                  <li>[=AllUserMediaElements/Queue an event=] named `track` on [=this=].</li>
 
                 </ol>
               </li>
@@ -2348,10 +2347,10 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>
-          <li>Set |result|["{{MediaStreamConstraints/video}}"] to a copy of
-            |constraints|.</li>
           <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a
-            > from |result|["{{MediaStreamConstraints/video}}"].</li>
+            > from |constraints|.</li>
+          <li>Set |result|["{{MediaStreamConstraints/video}}"] to
+            |constraints|.</li>
           <li>Return |result|.</li>
         </ol>
       </section>
@@ -2507,9 +2506,8 @@ onmessage = async ({data: {track}}) => {
         <div class=note>
           [^microphone^]'s [=EventTarget/activation behavior=]
           currently ignores activation when it already has a
-          {{HTMLMicrophoneElement/[[track]]}} set. The intent is that an element
-          with an ended track will start a new one. The behaviour for
-          an element with an active track still need to be determined.
+          {{HTMLMicrophoneElement/[[track]]}} set. The behaviour for
+          an element with a track still needs to be determined.
         </div>
 
         <p>The
@@ -2552,7 +2550,7 @@ onmessage = async ({data: {track}}) => {
                   <li>Set
                     {{HTMLMicrophoneElement/[[track]]}} to |tracks|[0].</li>
                   <li>Run the [=HTMLMicrophoneElement/track monitor=] steps on [=this=].</li>
-                  <li>[=Fire an event=] named `track` on [=this=].</li>
+                  <li>[=AllUserMediaElements/Queue an event=] named `track` on [=this=].</li>
 
                 </ol>
               </li>
@@ -2567,7 +2565,7 @@ onmessage = async ({data: {track}}) => {
                     [=this=], using {{DOMException}}, and return.</li>
                   <li>[=Assert=]: |r| is a |DOMException|.</li>
                   <li>Set {{HTMLMicrophoneElement/[[error]]}} to |r|.
-                  <li>[=Fire an event=] named `error` on [=this=],
+                  <li>[=AllUserMediaElements/Queue an event=] named `error` on [=this=],
                     using |r|.
                     (Description still TBD.)</li>
                 </ol>
@@ -2611,9 +2609,9 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>
-          <li>Set |result|["{{MediaStreamConstraints/audio}}"] to a copy of
+          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |constraints|</li>
+          <li>Set |result|["{{MediaStreamConstraints/audio}}"] to
             |constraints|.</li>
-          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["{{MediaStreamConstraints/audio}}"].</li>
           <li>Return |result|.</li>
         </ol>
       </section>
@@ -2624,7 +2622,7 @@ onmessage = async ({data: {track}}) => {
       <p>
         The &lt;<dfn data-dfn-type="element">usermedia</dfn>&gt; HTML element
         is an [[HTML]] element that can mediate access to a {{MediaStream}}
-        consisting of a microphone and camera track.
+        consisting of a microphone and a camera track.
         The [^usermedia^] element is {{SecureContext}} restricted. Outside
         of a [=secure context=] it uses the default [=element interface=].
         In a [=secure context=] it uses the following [=element interface=]:
@@ -2776,9 +2774,8 @@ onmessage = async ({data: {track}}) => {
         <div class=note>
           [^usermedia^]'s [=EventTarget/activation behavior=]
           currently ignores activation when it already has a
-          {{HTMLUserMediaElement/[[stream]]}} set. The intent is that an element
-          with an ended stream will start a new one. The behaviour for
-          an element with an active stream still need to be determined.
+          {{HTMLUserMediaElement/[[stream]]}} set. The behaviour for
+          an element with a stream still needs to be determined.
        </div>
 
 
@@ -2815,7 +2812,7 @@ onmessage = async ({data: {track}}) => {
                   <li>Set {{HTMLUserMediaElement/[[stream]]}} to |v|.</li>
                   <li>Run the [=HTMLUserMediaElement/track monitor=]
                     steps on [=this=].</li>
-                  <li>[=Fire an event=] named `stream` on [=this=].</li>
+                  <li>[=AllUserMediaElements/Queue an event=] named `stream` on [=this=].</li>
                 </ol>
               </li>
               <li>
@@ -2830,7 +2827,7 @@ onmessage = async ({data: {track}}) => {
                     [=this=], using {{DOMException}}, and return.</li>
                   <li>[=Assert=]: |r| is a |DOMException|.</li>
                   <li>Set {{HTMLUserMediaElement/[[error]]}} to |r|.
-                  <li>[=Fire an event=] named `error` on [=this=],
+                  <li>[=AllUserMediaElements/Queue an event=] named `error` on [=this=],
                     using {{DOMException}}. (Description still TBD.).</li>
                 </ol>
               </li>
@@ -2868,21 +2865,30 @@ onmessage = async ({data: {track}}) => {
         <ol class=algorithm>
           <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>
           <li>If |constraints|["{{HTMLMediaStreamConstraints/audio}}"]
-            [=map/exists=], set |result|["{{MediaStreamConstraints/audio}}"] to
-            a copy of |constraints|["{{HTMLMediaStreamConstraints/audio}}"].
-            Otherwise, set |result|["{{MediaStreamConstraints/audio}}"] to
+            [=map/exists=]:
+            <ol>
+              <li>Remove any
+                <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a>
+                from |constraints|["{{MediaStreamConstraints/audio}}"].</li>
+              <li>Set |result|["{{MediaStreamConstraints/audio}}"] to
+                |constraints|["{{HTMLMediaStreamConstraints/audio}}"].</li>
+            </ol>
+          </li>
+          <li>Otherwise, set |result|["{{MediaStreamConstraints/audio}}"] to
             an empty [=dictionary=].</li>
-          <li>Remove any
-            <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a>
-            from |result|["{{MediaStreamConstraints/audio}}"].</li>
           <li>If |constraints|["{{HTMLMediaStreamConstraints/video}}"]
-            [=map/exists=], set |result|["{{MediaStreamConstraints/video}}"] to
-            a copy of |constraints|["{{HTMLMediaStreamConstraints/video}}"].
+            [=map/exists=]:
+            <ol>
+              <li>Remove any
+                <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a>
+                from |constraints|["{{MediaStreamConstraints/video}}"].</li>
+              <li>Set |result|["{{MediaStreamConstraints/video}}"] to
+                |constraints|["{{HTMLMediaStreamConstraints/video}}"].</li>
+            </ol>
+          </li>
+          <li>
             Otherwise, set |result|["{{MediaStreamConstraints/video}}"] to an
             empty [=dictionary=].</li>
-          <li>Remove any
-            <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a>
-            from |result|["{{MediaStreamConstraints/video}}"].</li>
           <li>Return |result|.</li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -2096,9 +2096,9 @@ onmessage = async ({data: {track}}) => {
     <section>
       <h3>The &lt;<a>camera</a>&gt; HTML element</h3>
       <p>
-        The &lt;<dfn data-dfn-type="element">camera</dfn>&gt; HTML element is an [[HTML]]
-        element that can mediate access to a camera's video {{MediaStreamTrack}}, including handling
-        the required [=permission/prompts=] for [=powerful features=].
+        The &lt;<dfn data-dfn-type="element">camera</dfn>&gt; HTML element is an
+        [[HTML]] element that can mediate access to a camera's video
+        {{MediaStreamTrack}}.
       </p>
       <p>
         The &lt;<a>camera</a>&gt; element uses the following
@@ -2271,7 +2271,7 @@ onmessage = async ({data: {track}}) => {
           </li>
         </ol>
 
-        <p>To determine wheter an {{Event}} |event| is
+        <p>To determine whether an {{Event}} |event| is
           <dfn data-dfn-for=HTMLCameraElement>trusted</dfn>:</p>
 
         <p class=note>{{HTMLCameraElement}} stream creation is supposed to happen by
@@ -2333,9 +2333,9 @@ onmessage = async ({data: {track}}) => {
     <section>
       <h3>The &lt;<a>microphone</a>&gt; HTML element</h3>
       <p>
-        The &lt;<dfn data-dfn-type="element">microphone</dfn>&gt; HTML element is an [[HTML]]
-        element that can mediate access to a microphone's audio {{MediaStreamTrack}}, including handling
-        the required [=permission/prompts=] for [=powerful features=].
+        The &lt;<dfn data-dfn-type="element">microphone</dfn>&gt; HTML element
+        is an [[HTML]] element that can mediate access to a microphone's audio
+        {{MediaStreamTrack}}.
       </p>
       <p>
         The &lt;<a>microphone</a>&gt; element uses the following
@@ -2348,14 +2348,10 @@ onmessage = async ({data: {track}}) => {
 
         readonly attribute MediaStreamTrack? track;
         undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
-        readonly attribute any error;
-
-        attribute boolean autostart;
 
         attribute EventHandler onstream;
-        attribute EventHandler ontrackchange;
+        attribute EventHandler onerror;
       };
-      HTMLMicrophoneElement includes PowerfulFeatureObserver;
       </pre>
 
       <p>The &lt;<a>microphone</a>&gt; element uses the following internal slots:</p>
@@ -2368,11 +2364,7 @@ onmessage = async ({data: {track}}) => {
           <dfn data-dfn-for="HTMLMicrophoneElement">[[\constraints]]</dfn> &mdash;
           Holds a {{MediaTrackConstraintSet}}.
         </li>
-        <li>
-          <dfn data-dfn-for="HTMLMicrophoneElement">[[\error]]</dfn> &mdash;
-          Holds a {{DOMException}} or null.
-        </li>
-      </ul>
+     </ul>
 
       <p>
         The &lt;<a>microphone</a>&gt; element belongs to the [=flow content=],
@@ -2392,149 +2384,153 @@ onmessage = async ({data: {track}}) => {
           <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">global attributes</a>
         </dt>
         <dd>&mdash; all global content attributes.</dd>
-        <dt>
-          <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-powerfulfeatureobserver-attributes">PowerfulFeatureObserver attributes</a>
-        </dt>
-        <dd>&mdash; attributes provided by the PowerfulFeatureObserver mixin.</dd>
-        <dt>
-          <dfn data-dfn-for="HTMLMicrophoneElement">autostart</dfn>
-        </dt>
-        <dd>&mdash; A boolean attribute indicating whether to try to start the stream automatically as the element is added to the DOM and rendered.</dd>
-
       </dl>
+
+      <p>The &lt;<a>microphone</a>&gt; element's presentation is left to the
+        [=user agent=]. It's expected that the presentation is chiefly that of a
+        button, with text and/or an icon to indicate this will give camera
+        access. The presentation is expected to reflect the state of the
+        underlying stream (if any), e.g. by hinting to the user that a stream
+        is live
+(or not), or that the microphone might be open or muted.
+      </p>
 
       <section>
         <h4>Algorithms</h4>
 
-        <p>
-          The {{HTMLMicrophoneElement/constructor()}} steps are:
+        <p>The <dfn data-dfn-for=HTMLMicrophoneElement>constructor()</dfn>
+          steps are:
         </p>
         <ol class=algorithm>
-          <li>Initialize {{HTMLMicrophoneElement/[[track]]}} to null.</li>
-          <li>Initialize {{HTMLMicrophoneElement/[[error]]}} to null.</li>
-          <li>Initialize {{HTMLMicrophoneElement/[[constraints]]}} to [=this=]'s [=HTMLMicrophoneElement/default constraints=].</li>
-          <li>Initialize {{PowerfulFeatureObserver/[[Features]]}} to &laquo; "microphone" &raquo;.</li>
-          <li>Run <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver">PowerfulFeatureObserver</a>'s <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-initialization-steps">initialization steps</a>.</li>
+          <li>Initialize [=this=].{{HTMLMicrophoneElement/[[track]]}} to null.</li>
+          <li>Initialize [=this=].{{HTMLMicrophoneElement/[[constraints]]}} to «».</li>
         </ol>
 
-        <p>The &lt;<a>microphone</a>&gt; element's [=insertion steps=], given |element|, are:</p>
+        <p>The <dfn data-dfn-for=HTMLMicrophoneElement>track</dfn> <a>getter</a>
+          steps are:</p>
         <ol class=algorithm>
-          <li>
-            If |element| has an {{HTMLMicrophoneElement/autostart}} attribute, and {{HTMLMicrophoneElement/[[track]]}} is null,
-            run the [=HTMLMicrophoneElement/activation initial=] steps on |element|.
-          </li>
+          <li>Return [=this=].{{HTMLMicrophoneElement/[[track]]}}.</li>
         </ol>
 
-        <p>The {{HTMLMicrophoneElement/track}} <a>getter</a> steps are:</p>
-        <ol class=algorithm>
-          <li>Return {{HTMLMicrophoneElement/[[track]]}}.</li>
-        </ol>
-
-        <p>
-          The {{HTMLMicrophoneElement/setConstraints()}} steps for an |element| and
-          an optional |constraints| parameter are:
+        <p>The <dfn data-dfn-for=HTMLMicrophoneElement>setConstraints()</dfn> steps with
+          a parameter |constraints| are:
         </p>
         <ol class=algorithm>
           <li>
-            Set {{HTMLMicrophoneElement/[[constraints]]}} to the result of
-            [=HTMLMicrophoneElement/constraint filter=] for |element| and
+            Set [=this=].{{HTMLMicrophoneElement/[[constraints]]}} to the
+            result of [=HTMLMicrophoneElement/constraint filter=] for
             |constraints|.
           </li>
         </ol>
 
-        <p>The {{HTMLMicrophoneElement/error}} <a>getter</a> steps are:</p>
-        <ol class=algorithm>
-          <li>Return {{HTMLMicrophoneElement/[[error]]}}.</li>
-        </ol>
-
         <p>
-          The &lt;<a>microphone</a>&gt; <dfn data-dfn-for="HTMLMicrophoneElement">permission name</dfn>
-          is: [=/"microphone"=].
-        </p>
-
-        <p>
-          The &lt;<a>microphone</a>&gt;
-          <dfn data-dfn-for="HTMLMicrophoneElement">default constraints</dfn> are:
-          &laquo;[ ]&raquo;.
-        </p>
-
-        <p>
-          The &lt;<a>microphone</a>&gt; element's [=EventTarget/activation behavior=],
-          given |element|, is:
+          The &lt;<a>microphone</a>&gt; element's
+          [=EventTarget/activation behavior=] given |event| is:
         </p>
         <ol class=algorithm>
           <li>
-            If {{HTMLMicrophoneElement/[[track]]}} is null, run
+            If [=this=].{{HTMLMicrophoneElement/[[track]]}} is not null, then
+            run [=HTMLMicrophoneElement/activation second=] steps.
+          </li>
+          <li>
+            Otherwise: If |event| is [=HTMLMicrophoneElement/trusted=], then run
             [=HTMLMicrophoneElement/activation initial=] steps.
           </li>
-          <li>
-            Otherwise, run [=HTMLMicrophoneElement/activation second=] steps.
-          </li>
         </ol>
 
-        <p>The <dfn data-dfn-for="HTMLMicrophoneElement">activation initial</dfn> steps are:</p>
+        <p>The <dfn data-dfn-for="HTMLMicrophoneElement">activation initial</dfn>
+          steps are:</p>
+
         <ol class=algorithm>
-          <li>[=Assert=]: {{HTMLMicrophoneElement/[[track]]}} is null.</li>
-          <li>Let |permissionName| be |element|'s [=HTMLMicrophoneElement/permission name=].</li>
+          <li>[=Assert=]: [=this=].{{HTMLMicrophoneElement/[[track]]}} is null.</li>
           <li>
             Let |descriptor| be a new {{PermissionDescriptor}} with value
-            &laquo;[ {{PermissionDescriptor/name}} &rarr; |permissionName| ]&raquo;.
+            «[ {{PermissionDescriptor/name}} → [=/"microphone"=] ]».
           </li>
           <li>
             Let |permissionState| be the result of [=request permission to use=]
             the [=powerful features=] described by |descriptor| with
             allowMultiple set to false.
           </li>
-          <li>If |permissionState| is not {{PermissionState/"granted"}}:
+          <li>If |permissionState| is {{PermissionState/"granted"}}:
             <ol>
-              <li>Set {{HTMLMicrophoneElement/[[track]]}} to null.</li>
-              <li>Set {{HTMLMicrophoneElement/[[error]]}} to null.</li>
-              <li>Return.</li>
-            </ol>
-          </li>
-          <li>Let |constraints| be {{HTMLMicrophoneElement/[[constraints]]}}.</li>
-          <li>
-            Let |filteredConstraints| be the result of [=HTMLMicrophoneElement/constraint filter=] for |element| and |constraints|.
-          </li>
-          <li>
-            Let |mediaPromise| be the result of calling
-            {{MediaDevices/getUserMedia()}} with |filteredConstraints| as its first
-            argument.
-          </li>
-          <li>
-            [=promise/React=] to |mediaPromise|:
-            <ol>
-              <li>If |mediaPromise| was fulfilled with value |v|:
-                <ol>
-                  <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
-                  <li>Let |tracks| be the result of calling {{MediaStream/getAudioTracks()}} on |v|.</li>
-                  <li>If |tracks| is empty, set {{HTMLMicrophoneElement/[[track]]}} to null. Otherwise, set {{HTMLMicrophoneElement/[[track]]}} to |tracks|[0].</li>
-                  <li>Set {{HTMLMicrophoneElement/[[error]]}} to null.</li>
-                  <li>Run the [=HTMLMicrophoneElement/track monitor=] steps on |element|.</li>
-                  <li>[=Fire an event=] named `stream` at |element|.</li>
-                </ol>
+              <li>
+                Let |mediaPromise| be the result of calling
+                [=this=].{{MediaDevices/getUserMedia()}} with {{HTMLMicrophoneElement/[[constraints]]}}
+                as its first argument.
+
+                <div class=note>
+                The call to the {{MediaDevices/getUserMedia()}} method should
+                be replaced with anon-IDL entry point or algorithm.</div>
               </li>
               <li>
-                else:
+                [=promise/React=] to |mediaPromise|:
                 <ol>
-                  <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
-                  <li>[=Assert=]: |r| is a |DOMException|.</li>
-                  <li>Set {{HTMLMicrophoneElement/[[track]]}} to null.</li>
-                  <li>Set {{HTMLMicrophoneElement/[[error]]}} to |r|.</li>
-                  <li>[=Fire an event=] named `stream` at |element|.</li>
+                  <li>If |mediaPromise| was fulfilled with value |v|:
+                    <ol>
+                      <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
+                      <li>Let |tracks| be the result of calling {{MediaStream/getAudioTracks()}} on |v|.</li>
+                      <li>If |tracks| is not empty, set
+                        {{HTMLMicrophoneElement/[[track]]}} to |tracks|[0].</li>
+                      <li>If {{HTMLMicrophoneElement/[[track]]}} is null:
+                        <ol>
+                          <li>[=Fire an event=] named `error` on [=this=],
+                            using {{DOMException}}.
+                            (Description still TBD.)</li>
+                          <li>Return.</li>
+                        </ol>
+                      </li>
+                      <li>Run the [=HTMLMicrophoneElement/track monitor=] steps on [=this=].</li>
+                      <li>[=Fire an event=] named `stream` on [=this=].</li>
+
+                    </ol>
+                  </li>
+                  <li>Otherwise:</li>
+                    <ol>
+                      <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
+                      <li>[=Assert=]: |r| is a |DOMException|.</li>
+                      <li>[=Fire an event=] named `error` on [=this=],
+                        using {{DOMException}}.
+                        (Description still TBD.)</li>
+                      <li>Return.</li>
+                    </ol>
+                  </li>
                 </ol>
               </li>
             </ol>
+          </li>
+          <li>Otherwise, [=fire an event=] named `error` on [=this=],
+            using {{DOMException}}.
+            (Description still TBD.)</li>
+        </ol>
+
+        <p>The <dfn data-dfn-for="HTMLMicrophoneElement">activation second</dfn>
+          steps are:</p>
+        <ol class=algorithm>
+          <li>[=Assert=]: [=this=].{{HTMLMicrophoneElement/[[track]]}} is a
+            {{MediaStreamTrack}}.</li>
+          <li>
+            Set [=this=].{{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/enabled}}
+            to the negation of
+            [=this=].{{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/enabled}}.
           </li>
         </ol>
 
-        <p>The <dfn data-dfn-for="HTMLMicrophoneElement">activation second</dfn> steps are:</p>
+        <p>To determine whether an {{Event}} |event| is
+          <dfn data-dfn-for=HTMLMicrophoneElement>trusted</dfn>:</p>
+
+        <p class=note>{{HTMLMicrophoneElement}} stream creation is supposed to happen by
+          genuine user action. [=User agents=] SHOULD suppress activation
+          for "click-jacking", as well as for programmatic activation. Since
+          exact critera for these are difficult to specify, we presently leave
+          this as implementation defined. [=User agents=] MUST at minimum
+          reject untrusted events.</p>
+
         <ol class=algorithm>
-          <li>[=Assert=]: {{HTMLMicrophoneElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
-          <li>
-            Set {{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/enabled}} to the negation of
-            {{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/enabled}}.
-          </li>
+          <li>If |event|.{{Event/isTrusted}} is false: Return false.</li>
+          <li>[=User agents=] SHOULD run additional, implementation-defined steps
+            to determine trusted-ness of |event|.</li>
+          <li>Return true.</li>
         </ol>
 
         <p>The <dfn data-dfn-for="HTMLMicrophoneElement">track monitor</dfn> steps are:</p>
@@ -2542,10 +2538,17 @@ onmessage = async ({data: {track}}) => {
           <li>[=Assert=]: {{HTMLMicrophoneElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
           <li>
             The user agent MUST monitor the {{HTMLMicrophoneElement/[[track]]}}'s
-            {{MediaStreamTrack/readyState}} (specifically for
+            {{MediaStreamTrack/readyState}} (including for
             terminations triggered by {{MediaStreamTrack/stop()}}), its
             {{MediaStreamTrack/enabled}} state, and its
             {{MediaStreamTrack/muted}} state.
+            <div class=note>This monitoring is mostly provided by existing
+              event handlers on {{MediaStreamTrack}}, except that the
+              {{MediaStreamTrack/stop()}} method
+              <a href="https://w3c.github.io/mediacapture-main/#ends-nostop">will not dispatch any events</a>.
+              However, a track ending due to {{MediaStreamTrack/stop()}}
+              should still reflect the {{HTMLMicrophoneElement}} state.
+            </div>
           </li>
           <li>
             When the state of the monitored {{HTMLMicrophoneElement/[[track]]}} changes, the user agent MUST update the |element|'s
@@ -2559,14 +2562,14 @@ onmessage = async ({data: {track}}) => {
         </ol>
 
         <p>
-          The <dfn data-dfn-for="HTMLMicrophoneElement">constraint filter</dfn> steps for an
-          |element| and a {{MediaTrackConstraintSet}} |constraints| are:
+          The <dfn data-dfn-for="HTMLMicrophoneElement">constraint filter</dfn> steps
+          for a {{MediaTrackConstraintSet}} |constraints| are:
         </p>
         <ol class=algorithm>
           <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>
           <li>Set |result|["audio"] to a copy of |constraints|.</li>
-          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["audio"].</li>
           <li>Set |result|["video"] to false.</li>
+          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["audio"].</li>
           <li>Return |result|.</li>
         </ol>
       </section>
@@ -2575,9 +2578,9 @@ onmessage = async ({data: {track}}) => {
     <section>
       <h3>The &lt;<a>usermedia</a>&gt; HTML element</h3>
       <p>
-        The &lt;<dfn data-dfn-type="element">usermedia</dfn>&gt; HTML element is an [[HTML]]
-        element that can mediate access to a {{MediaStream}} consisting of one or more tracks, including handling
-        the required [=permission/prompts=] for [=powerful features=].
+        The &lt;<dfn data-dfn-type="element">usermedia</dfn>&gt; HTML element
+        is an [[HTML]] element that can mediate access to a {{MediaStream}}
+        consisting of one or more tracks.
       </p>
       <p>
         The &lt;<a>usermedia</a>&gt; element uses the following
@@ -2595,14 +2598,10 @@ onmessage = async ({data: {track}}) => {
 
         readonly attribute MediaStream? stream;
         undefined setConstraints(optional HTMLMediaStreamConstraints constraints = {});
-        readonly attribute any error;
-
-        attribute boolean autostart;
 
         attribute EventHandler onstream;
-        attribute EventHandler ontrackchange;
+        attribute EventHandler onerror;
       };
-      HTMLUserMediaElement includes PowerfulFeatureObserver;
       </pre>
 
       <p>The &lt;<a>usermedia</a>&gt; element uses the following internal slots:</p>
@@ -2614,10 +2613,6 @@ onmessage = async ({data: {track}}) => {
         <li>
           <dfn data-dfn-for="HTMLUserMediaElement">[[\constraints]]</dfn> &mdash;
           Holds an {{HTMLMediaStreamConstraints}}.
-        </li>
-        <li>
-          <dfn data-dfn-for="HTMLUserMediaElement">[[\error]]</dfn> &mdash;
-          Holds a {{DOMException}} or null.
         </li>
       </ul>
 
@@ -2639,136 +2634,152 @@ onmessage = async ({data: {track}}) => {
           <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">global attributes</a>
         </dt>
         <dd>&mdash; all global content attributes.</dd>
-        <dt>
-          <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-powerfulfeatureobserver-attributes">PowerfulFeatureObserver attributes</a>
-        </dt>
-        <dd>&mdash; attributes provided by the PowerfulFeatureObserver mixin.</dd>
-        <dt>
-          <dfn data-dfn-for="HTMLUserMediaElement">autostart</dfn>
-        </dt>
-        <dd>&mdash; A boolean attribute indicating whether to try to start the stream automatically as the element is added to the DOM and rendered.</dd>
-
       </dl>
+
+      <p>The &lt;<a>usermedia</a>&gt; element's presentation is left to the [=user
+        agent=]. It's expected that the presentation is chiefly that of a button,
+        with text and/or an icon to indicate this will give camera access.
+        The presentation is expected to reflect the state of the underlying
+        stream (if any), e.g. by hinting to the user that a stream is live
+        (or not), or that the microphone might be open or muted.
+      </p>
 
       <section>
         <h4>Algorithms</h4>
 
-        <p>
-          The {{HTMLUserMediaElement/constructor()}} steps are:
+        <p>The <dfn data-dfn-for=HTMLUserMediaElement>constructor()</dfn>
+          steps are:
         </p>
         <ol class=algorithm>
           <li>Initialize {{HTMLUserMediaElement/[[stream]]}} to null.</li>
-          <li>Initialize {{HTMLUserMediaElement/[[error]]}} to null.</li>
-          <li>Initialize {{HTMLUserMediaElement/[[constraints]]}} to [=this=]'s [=HTMLUserMediaElement/default constraints=].</li>
-          <li>Initialize {{PowerfulFeatureObserver/[[Features]]}} to &laquo; "camera", "microphone" &raquo;.</li>
-          <li>Run <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver">PowerfulFeatureObserver</a>'s <a href="https://wicg.github.io/PEPC/geolocation-element.html#powerfulfeatureobserver-initialization-steps">initialization steps</a>.</li>
+          <li>Initialize {{HTMLUserMediaElement/[[constraints]]}} to «».</li>
         </ol>
 
-        <p>The &lt;<a>usermedia</a>&gt; element's [=insertion steps=], given |element|, are:</p>
-        <ol class=algorithm>
-          <li>
-            If |element| has an {{HTMLUserMediaElement/autostart}} attribute, and {{HTMLUserMediaElement/[[stream]]}} is null,
-            run the [=HTMLUserMediaElement/activation initial=] steps on |element|.
-          </li>
-        </ol>
-
-        <p>The {{HTMLUserMediaElement/stream}} <a>getter</a> steps are:</p>
+        <p>The <dfn data-dfn-for=HTMLUserMediaElement>stream</dfn>
+          <a>getter</a> steps are:</p>
         <ol class=algorithm>
           <li>Return {{HTMLUserMediaElement/[[stream]]}}.</li>
         </ol>
 
-        <p>
-          The {{HTMLUserMediaElement/setConstraints()}} steps for an |element| and
-          an optional |constraints| parameter are:
+        <p>The <dfn data-dfn-for=HTMLUserMediaElement>setConstraints()</dfn>
+          steps with a parameter |constraints| are:
         </p>
         <ol class=algorithm>
           <li>
             Set {{HTMLUserMediaElement/[[constraints]]}} to the result of
-            [=HTMLUserMediaElement/constraint filter=] for |element| and
-            |constraints|.
+            [=HTMLUserMediaElement/constraint filter=] with |constraints|.
           </li>
         </ol>
-
-        <p>The {{HTMLUserMediaElement/error}} <a>getter</a> steps are:</p>
-        <ol class=algorithm>
-          <li>Return {{HTMLUserMediaElement/[[error]]}}.</li>
-        </ol>
-
-        <p>
-          The &lt;<a>usermedia</a>&gt; <dfn data-dfn-for="HTMLUserMediaElement">permission name</dfn>
-          is: The [=string/concatenate|concatentation=] of &laquo; [=/"camera"=], " ", [=/"microphone"=] &raquo;.
-        </p>
-
-        <p>
-          The &lt;<a>usermedia</a>&gt;
-          <dfn data-dfn-for="HTMLUserMediaElement">default constraints</dfn> are:
-          &laquo;[ "video" &rarr; &laquo;[ ]&raquo;, "audio" &rarr; &laquo;[ ]&raquo; ]&raquo;.
-        </p>
 
         <p>
           The &lt;<a>usermedia</a>&gt; element's [=EventTarget/activation behavior=],
-          given |element|, is:
+          given |event|, is:
         </p>
         <ol class=algorithm>
-          <li>
-            If {{HTMLUserMediaElement/[[stream]]}} is null, run
-            [=HTMLUserMediaElement/activation initial=] steps.
+          <li>If [=this=].{{HTMLUserMediaElement/[[stream]]}} is not null, then
+            run [=HTMLUserMediaElement/activation second=] steps.
+          </li>
+          <li>Otherwise: If |event| is [=HTMLUserMediaElement/trusted=], then
+            run [=HTMLUserMediaElement/activation initial=] steps.
           </li>
         </ol>
 
-        <p>The <dfn data-dfn-for="HTMLUserMediaElement">activation initial</dfn> steps are:</p>
+        <p>The <dfn data-dfn-for="HTMLUserMediaElement">activation initial</dfn>
+          steps are:</p>
         <ol class=algorithm>
-          <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is null.</li>
-          <li>Let |permissionName| be |element|'s [=HTMLUserMediaElement/permission name=].</li>
+          <li>[=Assert=]: [=this=].{{HTMLUserMediaElement/[[stream]]}} is
+            null.</li>
+          <li>Let |permissionName| be the [=string/concatenate|concatentation=]
+            of &laquo; [=/"camera"=], " ", [=/"microphone"=] &raquo;.
           <li>
             Let |descriptor| be a new {{PermissionDescriptor}} with value
-            &laquo;[ {{PermissionDescriptor/name}} &rarr; |permissionName| ]&raquo;.
+            &laquo;[ {{PermissionDescriptor/name}} &rarr; |permissionName|
+            ]&raquo;.
           </li>
           <li>
             Let |permissionState| be the result of [=request permission to use=]
             the [=powerful features=] described by |descriptor| with
             allowMultiple set to false.
           </li>
-          <li>If |permissionState| is not {{PermissionState/"granted"}}:
+          <li>If |permissionState| is {{PermissionState/"granted"}}:
             <ol>
-              <li>Set {{HTMLUserMediaElement/[[stream]]}} to null.</li>
-              <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
-              <li>Return.</li>
-            </ol>
-          </li>
-          <li>Let |constraints| be {{HTMLUserMediaElement/[[constraints]]}}.</li>
-          <li>
-            Let |filteredConstraints| be the result of [=HTMLUserMediaElement/constraint filter=] for |element| and |constraints|.
-          </li>
-          <li>
-            Let |mediaPromise| be the result of calling
-            {{MediaDevices/getUserMedia()}} with |filteredConstraints| as its first
-            argument.
-          </li>
-          <li>
-            [=promise/React=] to |mediaPromise|:
-            <ol>
-              <li>If |mediaPromise| was fulfilled with value |v|:
-                <ol>
-                  <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
-                  <li>Set {{HTMLUserMediaElement/[[stream]]}} to |v|.</li>
-                  <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
-                  <li>Run the [=HTMLUserMediaElement/track monitor=] steps on |element|.</li>
-                  <li>[=Fire an event=] named `stream` at |element|.</li>
-                </ol>
+              <li>Let |mediaPromise| be the result of calling
+                [=this=].{{MediaDevices/getUserMedia()}} with
+                {{HTMLUserMediaElement/[[constraints]]}} as its first argument.
+                <div class=note>
+                  The call to the {{MediaDevices/getUserMedia()}} method should
+                  be replaced with anon-IDL entry point or algorithm.
+                </div>
               </li>
-              <li>
-                else:
+              <li>[=promise/React=] to |mediaPromise|:
                 <ol>
-                  <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
-                  <li>[=Assert=]: |r| is a |DOMException|.</li>
-                  <li>Set {{HTMLUserMediaElement/[[stream]]}} to null.</li>
-                  <li>Set {{HTMLUserMediaElement/[[error]]}} to |r|.</li>
-                  <li>[=Fire an event=] named `stream` at |element|.</li>
+                  <li>If |mediaPromise| was fulfilled with value |v|:
+                    <ol>
+                      <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
+                      <li>Set {{HTMLUserMediaElement/[[stream]]}} to |v|.</li>
+                      <li>Run the [=HTMLUserMediaElement/track monitor=]
+                        steps on [=this=].</li>
+                      <li>[=Fire an event=] named `stream` on [=this=].</li>
+                    </ol>
+                  </li>
+                  <li>
+                    Otherwise:
+                    <ol>
+                      <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
+                      <li>[=Assert=]: |r| is a |DOMException|.</li>
+                      <li>[=Fire an event=] named `error` on [=this=],
+                        using {{DOMException}}. (Description still TBD.).</li>
+                      <li>Return.</li>
+                    </ol>
+                  </li>
                 </ol>
               </li>
             </ol>
           </li>
+          <li>[=Fire an event=] named `error` on [=this=],
+             using {{DOMException}}. (Description still TBD.).
+          </li>
+        </ol>
+
+        <p>
+          The &lt;<a>usermedia</a>&gt; element's
+          <dfn for=HTMLUserMediaElement>activation second</dfn> steps are:
+        </p>
+        <ol class=algorithm>
+          <li>[=Assert=]: [=this=].{{HTMLUserMediaElement/[[stream]]}} is a
+            {{MediaStream}}.</li>
+          <li>Let |enabled| be true.</li>
+          <li>
+            [=list/iterate|For each=] |track| of
+            {{HTMLUserMediaElement/[[stream]]}}'s [=/track set=]:
+            <ol>
+              <li>If |track|.{{MediaStreamTrack/enabled}} is false, set |enabled| to false.</li>
+            </ol>
+          </li>
+          <li>
+            [=list/iterate|For each=] |track| of
+            {{HTMLUserMediaElement/[[stream]]}}'s [=/track set=]:
+            <ol>
+              <li>Set |track|.{{MediaStreamTrack/enabled}} to the negation of |enabled|.</li>
+            </ol>
+          </li>
+        </ol>
+
+        <p>To determine whether an {{Event}} |event| is
+          <dfn data-dfn-for=HTMLUserMediaElement>trusted</dfn>:</p>
+
+        <p class=note>{{HTMLUserMediaElement}} stream creation is supposed to happen by
+          genuine user action. [=User agents=] SHOULD suppress activation
+          for "click-jacking", as well as for programmatic activation. Since
+          exact critera for these are difficult to specify, we presently leave
+          this as implementation defined. [=User agents=] MUST at minimum
+          reject untrusted events.</p>
+
+        <ol class=algorithm>
+          <li>If |event|.{{Event/isTrusted}} is false: Return false.</li>
+          <li>[=User agents=] SHOULD run additional, implementation-defined steps
+            to determine trusted-ness of |event|.</li>
+          <li>Return true.</li>
         </ol>
 
         <p>The <dfn data-dfn-for="HTMLUserMediaElement">track monitor</dfn> steps are:</p>
@@ -2784,7 +2795,7 @@ onmessage = async ({data: {track}}) => {
           </li>
           <li>
             When the state of any monitored |track| changes, the user agent MUST update the |element|'s
-            internal UI to reflect the active, muted, or ended state of the |track|, and [=Fire an event=] named `trackchange` at |element|.
+            internal UI to reflect the active, muted, or ended state of the |track|.
           </li>
           <li>
             If {{HTMLUserMediaElement/[[stream]]}}.{{MediaStream/active}} becomes false, the user agent MUST
@@ -2794,8 +2805,8 @@ onmessage = async ({data: {track}}) => {
         </ol>
 
         <p>
-          The <dfn data-dfn-for="HTMLUserMediaElement">constraint filter</dfn> steps for an
-          |element| and an {{HTMLMediaStreamConstraints}} |constraints| are:
+          The <dfn data-dfn-for="HTMLUserMediaElement">constraint filter</dfn>
+          for {{HTMLMediaStreamConstraints}} |constraints| are:
         </p>
         <ol class=algorithm>
           <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>

--- a/index.html
+++ b/index.html
@@ -1469,7 +1469,7 @@ partial dictionary MediaTrackCapabilities {
 };
         </pre>
         </p>
-      <h4>Processing considerations</h4>
+      <h3>Processing considerations</h3>
       <p>
         When the "voiceIsolation" setting is set to <code>true</code> by the
         <a>ApplyConstraints algorithm</a>, the UA
@@ -2177,8 +2177,7 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>
-            Set [=this=].{{HTMLCameraElement/[[constraints]]}} to the result of
-            [=HTMLCameraElement/constraint filter=] for |constraints|.
+            Set [=this=].{{HTMLCameraElement/[[constraints]]}} to |constraints|.
           </li>
         </ol>
 
@@ -2409,9 +2408,7 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>
-            Set [=this=].{{HTMLMicrophoneElement/[[constraints]]}} to the
-            result of [=HTMLMicrophoneElement/constraint filter=] for
-            |constraints|.
+            Set [=this=].{{HTMLMicrophoneElement/[[constraints]]}} to |constraints|.
           </li>
         </ol>
 
@@ -2652,7 +2649,7 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>
-            Set {{HTMLUserMediaElement/[[constraints]]}} to the result of
+            Set [=this=].{{HTMLUserMediaElement/[[constraints]]}} to the result of
             [=HTMLUserMediaElement/constraint filter=] with |constraints|.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
   var respecConfig = {
     group: "webrtc",
-    xref: ["geometry-1", "html", "infra", "permissions", "dom", "hr-time", "image-capture", "mediacapture-streams", "screen-capture", "webaudio", "webcodecs", "webidl", "ECMAScript"],
+    xref: ["geometry-1", "html", "infra", "permissions", "dom", "hr-time", "image-capture", "mediacapture-streams", "screen-capture", "webaudio", "webcodecs", "webidl", "ECMAScript", "geolocation-element"],
     edDraftURI: "https://w3c.github.io/mediacapture-extensions/",
     editors:  [
       {name: "Jan-Ivar Bruaroey", company: "Mozilla Corporation", w3cid: 79152},
@@ -2084,5 +2084,402 @@ onmessage = async ({data: {track}}) => {
       </pre>
     </section>
   </section>
-</body>
+
+  <section>
+    <h2>
+      The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
+      &lt;<a>microphone</a>&gt; media capture HTML elements
+    </h2>
+    <p>
+      The &lt;<dfn element>usermedia</dfn>&gt;, &lt;<dfn element>camera</dfn>&gt;,
+      and &lt;<dfn element>microphone</dfn>&gt; HTML elements are [[HTML]]
+      elements that can mediate access to a {{MediaStream}}, including handling
+      the required [=permission/prompts=] for [=powerful features=].
+    </p>
+    <p>
+      These three elements cover three different use cases and allow for use
+      case specific user interfaces in the [=user agent=]. Their
+      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">content attributes</a>
+      and IDL are mostly the same.
+    </p>
+    <p>
+      The &lt;<a>usermedia</a>&gt; element uses the following
+      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
+    </p>
+    <pre class=idl>
+      [Exposed=Window]
+      interface HTMLUserMediaElement : HTMLElement {
+        [HTMLConstructor] constructor();
+
+        readonly attribute MediaStream? stream;
+        undefined setConstraints(MediaStreamConstraints constraints);
+        readonly attribute any error;
+
+        attribute boolean autostart;
+
+        attribute EventHandler onstream;
+        attribute EventHandler ontrackchanged;
+      };
+      HTMLUserMediaElement includes ActivationBlockersMixin;
+    </pre>
+    <p>
+      The &lt;<a>camera</a>&gt; and &lt;<a>microphone</a>&gt;
+      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interfaces</a>
+      are almost the same. The &lt;<a>camera</a>&gt; element uses the following
+      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
+    </p>
+    <pre class=idl>
+      [Exposed=Window]
+      interface HTMLCameraElement : HTMLElement {
+        [HTMLConstructor] constructor();
+
+        readonly attribute MediaStream? stream;
+        undefined setConstraints(MediaStreamConstraints constraints);
+        readonly attribute any error;
+
+        attribute boolean autostart;
+
+        attribute EventHandler onstream;
+        attribute EventHandler ontrackchanged;
+      };
+      HTMLCameraElement includes ActivationBlockersMixin;
+    </pre>
+    <p>
+      The &lt;<a>microphone</a>&gt; element uses the following
+      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
+    </p>
+    <pre class=idl>
+      [Exposed=Window]
+      interface HTMLMicrophoneElement : HTMLElement {
+        [HTMLConstructor] constructor();
+
+        readonly attribute MediaStream? stream;
+        undefined setConstraints(MediaStreamConstraints constraints);
+        readonly attribute any error;
+
+        attribute boolean autostart;
+
+        attribute EventHandler onstream;
+        attribute EventHandler ontrackchanged;
+      };
+      HTMLMicrophoneElement includes ActivationBlockersMixin;
+    </pre>
+
+    <p>The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and &lt;<a>microphone</a>&gt; elements all use the following internal slots:</p>
+    <ul>
+      <li>
+        <dfn data-dfn-for="HTMLUserMediaElement">[[\stream]]</dfn> &mdash;
+        Holds null or a {{MediaStream}}.
+      </li>
+      <li>
+        <dfn data-dfn-for="HTMLUserMediaElement">[[\constraints]]</dfn> &mdash;
+        Holds a {{MediaStreamConstraints}}.
+      </li>
+      <li>
+        <dfn data-dfn-for="HTMLUserMediaElement">[[\error]]</dfn> &mdash;
+        Holds a {{DOMException}}, an {{OverconstrainedError}} or null.
+      </li>
+    </ul>
+
+    <p>
+      The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
+      &lt;<a>microphone</a>&gt; elements belong to the [=flow content=],
+      [=phrasing content=], [=interactive content=], and [=palpable content=]
+      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">categories</a>.
+      They can be used in contexts where [=phrasing content=] is expected. Their
+      content, if any, are their
+      <a href="https://html.spec.whatwg.org/multipage/dom.html#fallback-content">fallback content</a>.
+      They use the {{ActivationBlockersMixin}} from [[geolocation-element]], to
+      provide protection against programmatic activation.
+    </p>
+
+    <p>
+      The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
+      &lt;<a>microphone</a>&gt; elements all support the following
+      <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">content attributes</a>:
+    </p>
+    <dl>
+      <dt>
+        <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">global attributes</a>
+      </dt>
+      <dd>&mdash; all global content attributes.</dd>
+      <dt>
+        <dfn data-dfn-for="HTMLUserMediaElement">autostart</dfn>
+      </dt>
+      <dd>&mdash; A boolean attribute indicating whether to try to start the stream automatically as the element is added to the DOM and rendered.</dd>
+      <dt>
+        <a href="https://wicg.github.io/PEPC/geolocation-element.html#dom-activationblockersmixin-isvalid">isValid</a>
+      </dt>
+      <dt>
+        <a href="https://wicg.github.io/PEPC/geolocation-element.html#dom-activationblockersmixin-invalidreason">invalidReason</a>
+      </dt>
+      <dt>
+        <a href="https://wicg.github.io/PEPC/geolocation-element.html#dom-activationblockersmixin-onvalidationstatuschange">onvalidationstatuschange</a>
+      </dt>
+      <dd>&mdash; content attributes from {{ActivationBlockersMixin}}</dd>
+    </dl>
+
+    <section>
+      <h3>Algorithms</h3>
+
+      <p>
+        The {{HTMLUserMediaElement}}, {{HTMLCameraElement}}, and
+        {{HTMLMicrophoneElement}} all use the same constructor steps. Their
+        {{HTMLUserMediaElement/constructor()}} steps are:
+      </p>
+      <ol class=algorithm>
+        <li>Run {{ActivationBlockersMixin}}'s [=ActivationBlockersMixin/initialization steps=].</li>
+        <li>Initialize {{HTMLUserMediaElement/[[stream]]}} to null.</li>
+        <li>Initialize {{HTMLUserMediaElement/[[error]]}} to null.</li>
+        <li>Initialize {{HTMLUserMediaElement/[[constraints]]}} to [=this=]'s [=HTMLUserMediaElement/default constraints=].</li>
+      </ol>
+
+      <p>The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and &lt;<a>microphone</a>&gt; elements' [=insertion steps=], given |element|, are:</p>
+      <ol class=algorithm>
+        <li>
+          Run {{ActivationBlockersMixin}}'s
+          [=ActivationBlockersMixin/insertion steps=] given |element|.
+        </li>
+        <li>
+          If |element| has an {{HTMLUserMediaElement/autostart}} attribute, and {{HTMLUserMediaElement/[[stream]]}} is null,
+          run the [=HTMLUserMediaElement/activation initial=] steps on |element|.
+        </li>
+      </ol>
+
+      <p>The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and &lt;<a>microphone</a>&gt; elements' [=removing steps=], given |element|, are:</p>
+      <ol class=algorithm>
+        <li>
+          Run {{ActivationBlockersMixin}}'s
+          [=ActivationBlockersMixin/removing steps=] given |element|.
+        </li>
+      </ol>
+
+      <p>The {{HTMLUserMediaElement/stream}} <a>getter</a> steps are:</p>
+      <ol class=algorithm>
+        <li>Return {{HTMLUserMediaElement/[[stream]]}}.</li>
+      </ol>
+
+      <p>
+        The {{HTMLUserMediaElement/setConstraints()}} steps for an |element| and
+        a parameter |constraints| steps:
+      </p>
+      <ol class=algorithm>
+        <li>
+          Set {{HTMLUserMediaElement/[[constraints]]}} to the result of
+          [=HTMLUserMediaElement/constraint filter=] for |element| and
+          |constraints|.
+        </li>
+      </ol>
+
+      <p>The {{HTMLUserMediaElement/error}} <a>getter</a> steps are:</p>
+      <ol class=algorithm>
+        <li>Return {{HTMLUserMediaElement/[[error]]}}.</li>
+      </ol>
+
+      <p>
+        The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
+        &lt;<a>microphone</a>&gt; <dfn for=HTMLUserMediaElement>permission name</dfn>
+        are:
+      </p>
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Element type</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>&lt;<a>usermedia</a>&gt;</th>
+            <td>
+              The [=string/concatenate|concatentation=] of &laquo; [=/"camera"=],
+              " ", [=/"microphone"=] &raquo;.
+            </td>
+          </tr>
+          <tr>
+            <th>&lt;<a>camera</a>&gt;</th>
+            <td>[=/"camera"=]</td>
+          </tr>
+          <tr>
+            <th>&lt;<a>microphone</a>&gt;</th>
+            <td>[=/"microphone"=]</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
+        &lt;<a>microphone</a>&gt;
+        <dfn for=HTMLUserMediaElement>default constraints</dfn> are:
+      </p>
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Element type</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>&lt;<a>usermedia</a>&gt;</th>
+            <td>
+              &laquo;[ {{MediaStreamConstraints/video}} &rarr; true,
+              {{MediaStreamConstraints/audio}} &rarr; true ]&raquo;
+            </td>
+          </tr>
+          <tr>
+            <th>&lt;<a>camera</a>&gt;</th>
+            <td>
+              &laquo;[ {{MediaStreamConstraints/video}} &rarr; true,
+              {{MediaStreamConstraints/audio}} &rarr; false ]&raquo;
+            </td>
+          </tr>
+          <tr>
+            <th>&lt;<a>microphone</a>&gt;</th>
+            <td>
+              &laquo;[ {{MediaStreamConstraints/video}} &rarr; false,
+              {{MediaStreamConstraints/audio}} &rarr; true ]&raquo;
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        The &lt;<a>usermedia</a>&gt;, &lt;<a>camera</a>&gt;, and
+        &lt;<a>microphone</a>&gt; elements' [=EventTarget/activation behavior=],
+        given |element|, is:
+      </p>
+      <ol class=algorithm>
+        <li>
+          If |element|.{{ActivationBlockersMixin/isValid}} is false, then return.
+        </li>
+        <li>
+          If {{HTMLUserMediaElement/[[stream]]}} is null, run
+          [=HTMLUserMediaElement/activation initial=] steps.
+        </li>
+        <li>
+          Otherwise, if |element| is a {{HTMLCameraElement}} or a
+          {{HTMLMicrophoneElement}}, run
+          [=HTMLUserMediaElement/activation second=] steps.
+        </li>
+      </ol>
+
+      <p>The <dfn for=HTMLUserMediaElement>activation initial</dfn> steps are:</p>
+      <ol class=algorithm>
+        <li>[=Assert=]: |element|.{{ActivationBlockersMixin/isValid}}.</li>
+        <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is null.</li>
+        <li>Let |permissionName| be |element|'s [=permission name=].</li>
+        <li>
+          Let |descriptor| be a new {{PermissionDescriptor}} with value
+          &laquo;[ {{PermissionDescriptor/name}} &rarr; |permissionName| ]&raquo;.
+        </li>
+        <li>
+          Let |permissionState| be the result of [=request permission to use=]
+          the [=powerful features=] described by |descriptor| with
+          allowMultiple set to false.
+        </li>
+        <li>If |permissionState| is not {{PermissionState/"granted"}}:</li>
+        <ol>
+          <li>Set {{HTMLUserMediaElement/[[stream]]}} to null.</li>
+          <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
+          <li>Return.</li>
+        </ol>
+        <li>Let |contraints| be {{HTMLUserMediaElement/[[constraints]]}}.</li>
+        <li>
+          Let |mediaPromise| be the result of calling
+          {{MediaDevices/getUserMedia()}} with |constraints| as its first
+          argument.
+        </li>
+        <li>
+          [=promise/React=] to |mediaPromise|:
+          <ol>
+            <li>If |mediaPromise| was fulfilled with value |v|:</li>
+            <ol>
+              <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
+              <li>Set {{HTMLUserMediaElement/[[stream]]}} to |v|.</li>
+              <li>Set {{HTMLUserMediaElement/[[error]]}} to null.</li>
+              <li>Run the [=HTMLUserMediaElement/track monitor=] steps on |element|.</li>
+              <li>[=Fire an event=] named `stream` at |element|.</li>
+            </ol>
+            <li>
+              else:
+              <ol>
+                <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
+                <li>[=Assert=]: |r| is a |DOMException| or an |OverConstrainedError|.</li>
+                <li>Set {{HTMLUserMediaElement/[[stream]]}} to null.</li>
+                <li>Set {{HTMLUserMediaElement/[[error]]}} to |r|.</li>
+                <li>[=Fire an event=] named `stream` at |element|.</li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+      </ol>
+
+      <p>The <dfn for=HTMLUserMediaElement>activation second</dfn> steps are:</p>
+      <ol class=algorithm>
+        <li>[=Assert=]: |element|.{{ActivationBlockersMixin/isValid}}.</li>
+        <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is a {{MediaStream}}.</li>
+        <li>
+          For each |track| in the result of calling {{MediaStream/getTracks()}}
+          on {{HTMLUserMediaElement/[[stream]]}}:
+          <ol>
+            <li>
+              Set |track|.{{MediaStreamTrack/enabled}} to the negation of
+              |track|.{{MediaStreamTrack/enabled}}.
+            </li>
+          </ol>
+        </li>
+      </ol>
+
+      <p>The <dfn for=HTMLUserMediaElement>track monitor</dfn> steps are:</p>
+      <ol class=algorithm>
+        <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is a {{MediaStream}}.</li>
+        <li>
+          For each |track| in the result of calling {{MediaStream/getTracks()}}
+          on {{HTMLUserMediaElement/[[stream]]}}, the user agent MUST monitor
+          the |track|'s {{MediaStreamTrack/readyState}} (specifically for
+          terminations triggered by {{MediaStreamTrack/stop()}}), its
+          {{MediaStreamTrack/enabled}} state, and its
+          {{MediaStreamTrack/muted}} state.
+        </li>
+        <li>
+          When the state of any monitored |track| changes, the user agent MUST update the |element|'s
+          internal UI to reflect the active, muted, or ended state of the |track|, and [=Fire an event=] named `trackchanged` at |element|.
+        </li>
+        <li>
+          If {{HTMLUserMediaElement/[[stream]]}}.{{MediaStream/active}} becomes false, the user agent MUST
+          set {{HTMLUserMediaElement/[[stream]]}} to null and reset the |element|'s
+          internal UI to its initial request state.
+        </li>
+      </ol>
+
+      <p>
+        The <dfn for=HTMLUserMediaElement>constraint filter</dfn> steps for an
+        |element| and {{MediaStreamConstraints}} |constraints| are:
+      </p>
+      <ol class=algorithm>
+        <li>Let |result| be a new [=dictionary=].</li>
+        <li>
+          If |element| is a {{HTMLUserMediaElement}}, set |result| to &laquo;[
+            {{MediaStreamConstraints/audio}} &rarr; |constraints| [{{MediaStreamConstraints/audio}}],
+            {{MediaStreamConstraints/video}} &rarr; |constraints| [{{MediaStreamConstraints/video}}]
+          ]&raquo;.
+        </li>
+        <li>
+          Otherwise, if |element| is a {{HTMLMicrophoneElement}}, set |result| to &laquo;[
+            {{MediaStreamConstraints/audio}} &rarr; |constraints| [{{MediaStreamConstraints/audio}}],
+            {{MediaStreamConstraints/video}} &rarr; false
+          ]&raquo;.
+        </li>
+        <li>
+          Otherwise, if |element| is a {{HTMLCameraElement}}, set |result| to &laquo;[
+            {{MediaStreamConstraints/audio}} &rarr; false,
+            {{MediaStreamConstraints/video}} &rarr; |constraints| [{{MediaStreamConstraints/video}}]
+          ]&raquo;.
+        </li>
+        <li>Return |result|.</li>
+      </ol>
+    </section>
+  </section>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1469,7 +1469,7 @@ partial dictionary MediaTrackCapabilities {
 };
         </pre>
         </p>
-      <h4>Processing considerations</h4>
+      <h3>Processing considerations</h3>
       <p>
         When the "voiceIsolation" setting is set to <code>true</code> by the
         <a>ApplyConstraints algorithm</a>, the UA

--- a/index.html
+++ b/index.html
@@ -2085,7 +2085,7 @@ onmessage = async ({data: {track}}) => {
     </section>
   </section>
 
-  <section>
+  <section id="media-capture-html-elements">
     <h2>Media capture HTML elements</h2>
     <p>
       The following are [[HTML]] elements that let the user initiate media
@@ -2094,15 +2094,14 @@ onmessage = async ({data: {track}}) => {
     </p>
 
     <section>
-      <h3>The &lt;<a>camera</a>&gt; HTML element</h3>
+      <h3>The [^camera^] HTML element</h3>
       <p>
         The &lt;<dfn data-dfn-type="element">camera</dfn>&gt; HTML element is an
         [[HTML]] element that can mediate access to a camera's video
         {{MediaStreamTrack}}.
-      </p>
-      <p>
-        The &lt;<a>camera</a>&gt; element uses the following
-        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
+        The [^camera^] element is {{SecureContext}} restricted. Outside
+        of a [=secure context=] it uses the default [=element interface=].
+        In a [=secure context=] it uses the following [=element interface=]:
       </p>
       <pre class=idl>
       [Exposed=Window, SecureContext]
@@ -2119,7 +2118,7 @@ onmessage = async ({data: {track}}) => {
       };
       </pre>
 
-      <p>The &lt;<a>camera</a>&gt; element uses the following internal slots:</p>
+      <p>The [^camera^] element uses the following internal slots:</p>
       <ul>
         <li>
           <dfn data-dfn-for="HTMLCameraElement">[[\track]]</dfn> &mdash;
@@ -2135,7 +2134,7 @@ onmessage = async ({data: {track}}) => {
         </li>
       </ul>
 
-      <p>The &lt;<a>camera</a>&gt; element's activation is filtered to allow
+      <p>The [^camera^] element's activation is filtered to allow
         only activitations that result from genuine user action. Each activation
         is expected to fire an event on one of three event handlers, depending
         on whether the activation was successful:</p>
@@ -2161,7 +2160,7 @@ onmessage = async ({data: {track}}) => {
       </ul>
 
       <p>
-        The &lt;<a>camera</a>&gt; element belongs to the [=flow content=],
+        The [^camera^] element belongs to the [=flow content=],
         [=phrasing content=], [=interactive content=], and [=palpable content=]
         <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">categories</a>.
         It can be used in contexts where [=phrasing content=] is expected. Its
@@ -2170,7 +2169,7 @@ onmessage = async ({data: {track}}) => {
       </p>
 
       <p>
-        The &lt;<a>camera</a>&gt; element supports the following
+        The [^camera^] element supports the following
         <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">content attributes</a>:
       </p>
       <dl>
@@ -2184,9 +2183,9 @@ onmessage = async ({data: {track}}) => {
         <dd>&mdash; [=event handler IDL attributes=]</dd>
       </dl>
 
-      <p>The &lt;<a>camera</a>&gt; element's presentation is left to the [=user
+      <p>The [^camera^] element's presentation is left to the [=user
         agent=]. It's expected that the presentation is chiefly that of a button,
-        with text and/or an icon to indicate this will give camera access.
+        with text and/or an icon to indicate this is managing camera access.
         The presentation is expected to reflect the state of the underlying
         track (if any), e.g. by hinting to the user that a track is live
         (or not), or that the camera might be open or muted.
@@ -2227,27 +2226,30 @@ onmessage = async ({data: {track}}) => {
         </ol>
 
         <p>
-          The &lt;<a>camera</a>&gt; element's [=EventTarget/activation behavior=]
+          The [^camera^] element's [=EventTarget/activation behavior=]
           given |event| is:
         </p>
         <ol class=algorithm>
-          <li>If |event| is not [=HTMLCameraElement/trusted=], then
-            [=fire an event=] named `error`, using an "{{InvalidStateError}}"
-            {{DOMException}}.
+          <li>If |event| is not [=AllUserMediaElements/trusted=], then
+            [=AllUserMediaElements/queue an event=] named `error` on [=this=],
+            using an "{{InvalidStateError}}" {{DOMException}} and abort these
+            steps.
           </li>
-          <li>Otherwise, if {{HTMLCameraElement/[[track]]}} is not null, then run
-            [=HTMLCameraElement/activation start stream=] steps given [=this=].
+          <li>If {{HTMLCameraElement/[[track]]}} is not null, then abort these
+            steps.
+            <div class=note>
+              [^camera^]'s [=EventTarget/activation behavior=]
+              currently ignores activation when it already has a
+              {{HTMLCameraElement/[[track]]}} set. The intent is that an element
+              with an ended track will start a new one. The behaviour for
+              an element with an active track still need to be determined.
+            </div>
+          </li>
+          <li>Run [=HTMLCameraElement/activation start stream=] steps given
+            [=this=].
           </li>
         </ol>
 
-        <div class=note>
-          &lt;<a>camera</a>&gt;'s [=EventTarget/activation behavior=]
-          currently ignores activation when it already has a
-          {{HTMLCameraElement/[[track]]}} set. The intent is that an element
-          with an inactive track will start a new one. And an element with an
-          active track will act as a toggle to allow users to control the
-          stream. The details still need to be determined.
-        </div>
 
         <p>The <dfn data-dfn-for="HTMLCameraElement">activation start stream</dfn>
         steps for a given |element| are:</p>
@@ -2259,8 +2261,12 @@ onmessage = async ({data: {track}}) => {
             as its first argument.
 
             <div class=note>
-            The call to the {{MediaDevices/getUserMedia()}} method should
-            be replaced with a non-IDL entry point or algorithm.</div>
+              The call to the {{MediaDevices/getUserMedia()}} method should
+              be replaced with a non-IDL entry point or algorithm.
+              Any such a replacement must have precisely the same side effects
+              on the [[[?RFC8828#section-5.2|mode]]] defined in [[?RFC8828]] as
+              calling the IDL entry point.
+            </div>
             <div class=note>
               {{MediaDevices/getUserMedia()}} encourages User Agents
               <q>to bundle concurrent requests for different kinds of media
@@ -2280,7 +2286,7 @@ onmessage = async ({data: {track}}) => {
                   <li>Let |tracks| be the set of {{MediaStreamTrack}}s in
                     |v|'s [=/track set=] whose {{MediaStreamTrack/kind}}
                     is equal to "video".</li>
-                  <li>[=Assert=]: |tracks|[0] [=set/exists=].</li>
+                  <li>[=Assert=]: |tracks|'s [=list/size=] is 1.</li>
                   <li>Set
                     {{HTMLCameraElement/[[track]]}} to |tracks|[0].</li>
                   <li>Run the [=HTMLCameraElement/track monitor=] steps on [=this=].</li>
@@ -2295,45 +2301,26 @@ onmessage = async ({data: {track}}) => {
                     call has failed due to user action or inaction, such as a
                     user rejecting or not answering a permission prompt raised
                     by {{MediaDevices/getUserMedia()}}, then
-                    [=fire an event=] named `cancel` on [=this=], using
-                    {{DOMException}}, and return.</li>
+                    [=AllUserMediaElements/queue an event=] named `cancel` on
+                    [=this=], using {{DOMException}}, and return.</li>
                   <li>[=Assert=]: |r| is a |DOMException|.</li>
                   <li>Set [=this=].{{HTMLCameraElement/[[error]]}} to |r|.
-                  <li>[=Fire an event=] named `error` on [=this=],
-                    using |r|.
+                  <li>[=AllUserMediaElements/Queue an event=] named `error`
+                    on [=this=], using |r|.
                     (Description still TBD.)</li>
-                  <li>Return.</li>
                 </ol>
               </li>
             </ol>
           </li>
         </ol>
 
-        <p>To determine whether an {{Event}} |event| is
-          <dfn data-dfn-for=HTMLCameraElement>trusted</dfn>:</p>
-
-        <div class=note>{{HTMLCameraElement}} stream creation is supposed to happen by
-          genuine user action. [=User agents=] SHOULD suppress activation
-          for "click-jacking", as well as for programmatic activation. Since
-          exact critera for these are difficult to specify, we presently leave
-          this as implementation defined. [=User agents=] MUST at minimum
-          reject untrusted events.</div>
-
-        <ol class=algorithm>
-          <li>If |event|.{{Event/isTrusted}} is false: Return false.</li>
-          <li>[=User agents=] SHOULD run additional, implementation-defined steps
-            to determine trusted-ness of |event|.</li>
-          <li>Return true.</li>
-        </ol>
-
         <p>The <dfn data-dfn-for="HTMLCameraElement">track monitor</dfn> steps are:</p>
         <ol class=algorithm>
           <li>[=Assert=]: {{HTMLCameraElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
           <li>
-            The user agent MUST monitor the {{HTMLCameraElement/[[track]]}}'s
+            The user agent monitors the {{HTMLCameraElement/[[track]]}}'s
             {{MediaStreamTrack/readyState}} (including for
-            terminations triggered by {{MediaStreamTrack/stop()}}), its
-            {{MediaStreamTrack/enabled}} state, and its
+            terminations triggered by {{MediaStreamTrack/stop()}}), and its
             {{MediaStreamTrack/muted}} state.
             <div class=note>This monitoring is mostly provided by existing
               event handlers on {{MediaStreamTrack}}, except that the
@@ -2344,12 +2331,13 @@ onmessage = async ({data: {track}}) => {
             </div>
           </li>
           <li>
-            When the state of the monitored {{HTMLCameraElement/[[track]]}} changes, the user agent MUST update the |element|'s
-            internal UI to reflect the active, muted, or ended state of the track.
+            When the state of the monitored {{HTMLCameraElement/[[track]]}}
+            changes, the user agent updates the |element|'s internal UI to
+            reflect the active, muted, or ended state of the track.
           </li>
           <li>
             If {{HTMLCameraElement/[[track]]}}.{{MediaStreamTrack/readyState}}
-            becomes `"ended"`, the user agent MUST update its presentation
+            becomes `"ended"`, the user agent updates its presentation
             appropriately.
           </li>
         </ol>
@@ -2360,24 +2348,24 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>
-          <li>Set |result|["audio"] to false.</li>
-          <li>Set |result|["video"] to a copy of |constraints|.</li>
-          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["video"].</li>
+          <li>Set |result|["{{MediaStreamConstraints/video}}"] to a copy of
+            |constraints|.</li>
+          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a
+            > from |result|["{{MediaStreamConstraints/video}}"].</li>
           <li>Return |result|.</li>
         </ol>
       </section>
     </section>
 
     <section>
-      <h3>The &lt;<a>microphone</a>&gt; HTML element</h3>
+      <h3>The [^microphone^] HTML element</h3>
       <p>
         The &lt;<dfn data-dfn-type="element">microphone</dfn>&gt; HTML element
         is an [[HTML]] element that can mediate access to a microphone's audio
         {{MediaStreamTrack}}.
-      </p>
-      <p>
-        The &lt;<a>microphone</a>&gt; element uses the following
-        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
+        The [^microphone^] element is {{SecureContext}} restricted. Outside
+        of a [=secure context=] it uses the default [=element interface=].
+        In a [=secure context=] it uses the following [=element interface=]:
       </p>
       <pre class=idl>
       [Exposed=Window, SecureContext]
@@ -2394,7 +2382,7 @@ onmessage = async ({data: {track}}) => {
       };
       </pre>
 
-      <p>The &lt;<a>microphone</a>&gt; element uses the following internal slots:</p>
+      <p>The [^microphone^] element uses the following internal slots:</p>
       <ul>
         <li>
           <dfn data-dfn-for="HTMLMicrophoneElement">[[\track]]</dfn> &mdash;
@@ -2410,7 +2398,7 @@ onmessage = async ({data: {track}}) => {
         </li>
      </ul>
 
-     <p>The &lt;<a>microphone</a>&gt; element's activation is filtered to allow
+     <p>The [^microphone^] element's activation is filtered to allow
         only activitations that result from genuine user action. Each activation
         is expected to fire an event on one of three event handlers, depending
         on whether the activation was successful:</p>
@@ -2436,7 +2424,7 @@ onmessage = async ({data: {track}}) => {
       </ul>
 
       <p>
-        The &lt;<a>microphone</a>&gt; element belongs to the [=flow content=],
+        The [^microphone^] element belongs to the [=flow content=],
         [=phrasing content=], [=interactive content=], and [=palpable content=]
         <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">categories</a>.
         It can be used in contexts where [=phrasing content=] is expected. Its
@@ -2445,7 +2433,7 @@ onmessage = async ({data: {track}}) => {
       </p>
 
       <p>
-        The &lt;<a>microphone</a>&gt; element supports the following
+        The [^microphone^] element supports the following
         <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">content attributes</a>:
       </p>
       <dl>
@@ -2459,9 +2447,9 @@ onmessage = async ({data: {track}}) => {
         <dd>&mdash; [=event handler IDL attributes=]</dd>
       </dl>
 
-      <p>The &lt;<a>microphone</a>&gt; element's presentation is left to the
+      <p>The [^microphone^] element's presentation is left to the
         [=user agent=]. It's expected that the presentation is chiefly that of a
-        button, with text and/or an icon to indicate this will give microphone
+        button, with text and/or an icon to indicate this is managing microphone
         access. The presentation is expected to reflect the state of the
         underlying track (if any), e.g. by hinting to the user that a track
         is live (or not), or that the microphone might be open or muted.
@@ -2501,28 +2489,27 @@ onmessage = async ({data: {track}}) => {
         </ol>
 
         <p>
-          The &lt;<a>microphone</a>&gt; element's
+          The [^microphone^] element's
           [=EventTarget/activation behavior=] given |event| is:
         </p>
         <ol class=algorithm>
-          <li>If |event| is not [=HTMLMicrophoneElement/trusted=], then
-            [=fire an event=] named `error`, using an "{{InvalidStateError}}"
-            {{DOMException}}.
+          <li>If |event| is not [=AllUserMediaElements/trusted=], then
+            [=AllUserMediaElements/queue an event=] named `error`, using an
+            "{{InvalidStateError}}" {{DOMException}}.
           </li>
           <li>
-            Otherwise, if {{HTMLMicrophoneElement/[[track]]}} is not null, then
+            Otherwise, if {{HTMLMicrophoneElement/[[track]]}} is null, then
             run [=HTMLMicrophoneElement/activation start stream=] steps given
             [=this=].
           </li>
         </ol>
 
         <div class=note>
-          &lt;<a>microphone</a>&gt;'s [=EventTarget/activation behavior=]
+          [^microphone^]'s [=EventTarget/activation behavior=]
           currently ignores activation when it already has a
           {{HTMLMicrophoneElement/[[track]]}} set. The intent is that an element
-          with an inactive track will start a new one. And an element with an
-          active track will act as a toggle to allow users to control the
-          stream. The details still need to be determined.
+          with an ended track will start a new one. The behaviour for
+          an element with an active track still need to be determined.
         </div>
 
         <p>The
@@ -2536,8 +2523,12 @@ onmessage = async ({data: {track}}) => {
             [=this=].{{MediaDevices/getUserMedia()}} with
             {{HTMLMicrophoneElement/[[constraints]]}} as its first argument.
             <div class=note>
-            The call to the {{MediaDevices/getUserMedia()}} method should
-            be replaced with a non-IDL entry point or algorithm.</div>
+              The call to the {{MediaDevices/getUserMedia()}} method should
+              be replaced with a non-IDL entry point or algorithm.
+              Any such a replacement must have precisely the same side effects
+              on the [[[?RFC8828#section-5.2|mode]]] defined in [[?RFC8828]] as
+              calling the IDL entry point.
+            </div>
             <div class=note>
               {{MediaDevices/getUserMedia()}} encourages User Agents
               <q>to bundle concurrent requests for different kinds of media
@@ -2556,8 +2547,8 @@ onmessage = async ({data: {track}}) => {
                   <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
                   <li>Let |tracks| be the set of {{MediaStreamTrack}}s in
                     |v|'s [=/track set=] whose {{MediaStreamTrack/kind}}
-                    is equal to "audio".</li>
-                  <li>[=Assert=]: |tracks|[0] [=set/exists=].</li>
+                    is equal to `"audio"`.</li>
+                  <li>[=Assert=]: |tracks|'s [=list/size=] is 1.</li>
                   <li>Set
                     {{HTMLMicrophoneElement/[[track]]}} to |tracks|[0].</li>
                   <li>Run the [=HTMLMicrophoneElement/track monitor=] steps on [=this=].</li>
@@ -2572,42 +2563,24 @@ onmessage = async ({data: {track}}) => {
                     call has failed due to user action or inaction, such as a
                     user rejecting or not answering a permission prompt raised
                     by {{MediaDevices/getUserMedia()}}, then
-                    [=fire an event=] named `cancel` on [=this=], using
-                    {{DOMException}}, and return.</li>
+                    [=AllUserMediaElements/queue an event=] named `cancel` on
+                    [=this=], using {{DOMException}}, and return.</li>
                   <li>[=Assert=]: |r| is a |DOMException|.</li>
                   <li>Set {{HTMLMicrophoneElement/[[error]]}} to |r|.
                   <li>[=Fire an event=] named `error` on [=this=],
                     using |r|.
                     (Description still TBD.)</li>
-                  <li>Return.</li>
                 </ol>
               </li>
             </ol>
           </li>
         </ol>
 
-        <p>To determine whether an {{Event}} |event| is
-          <dfn data-dfn-for=HTMLMicrophoneElement>trusted</dfn>:</p>
-
-        <div class=note>{{HTMLMicrophoneElement}} stream creation is supposed to happen by
-          genuine user action. [=User agents=] SHOULD suppress activation
-          for "click-jacking", as well as for programmatic activation. Since
-          exact critera for these are difficult to specify, we presently leave
-          this as implementation defined. [=User agents=] MUST at minimum
-          reject untrusted events.</div>
-
-        <ol class=algorithm>
-          <li>If |event|.{{Event/isTrusted}} is false: Return false.</li>
-          <li>[=User agents=] SHOULD run additional, implementation-defined steps
-            to determine trusted-ness of |event|.</li>
-          <li>Return true.</li>
-        </ol>
-
         <p>The <dfn data-dfn-for="HTMLMicrophoneElement">track monitor</dfn> steps are:</p>
         <ol class=algorithm>
           <li>[=Assert=]: {{HTMLMicrophoneElement/[[track]]}} is a {{MediaStreamTrack}}.</li>
           <li>
-            The user agent MUST monitor the {{HTMLMicrophoneElement/[[track]]}}'s
+            The user agent monitors the {{HTMLMicrophoneElement/[[track]]}}'s
             {{MediaStreamTrack/readyState}} (including for
             terminations triggered by {{MediaStreamTrack/stop()}}), its
             {{MediaStreamTrack/enabled}} state, and its
@@ -2621,12 +2594,13 @@ onmessage = async ({data: {track}}) => {
             </div>
           </li>
           <li>
-            When the state of the monitored {{HTMLMicrophoneElement/[[track]]}} changes, the user agent MUST update the |element|'s
-            internal UI to reflect the active, muted, or ended state of the track.
+            When the state of the monitored {{HTMLMicrophoneElement/[[track]]}}
+            changes, the user agent updates the |element|'s internal UI to
+            reflect the active, muted, or ended state of the track.
           </li>
           <li>
             If {{HTMLMicrophoneElement/[[track]]}}.{{MediaStreamTrack/readyState}}
-            becomes `"ended"`, the user agent MUST update its presentation
+            becomes `"ended"`, the user agent updates its presentation
             appropriately.
           </li>
         </ol>
@@ -2637,24 +2611,23 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>
-          <li>Set |result|["audio"] to a copy of |constraints|.</li>
-          <li>Set |result|["video"] to false.</li>
-          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["audio"].</li>
+          <li>Set |result|["{{MediaStreamConstraints/audio}}"] to a copy of
+            |constraints|.</li>
+          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["{{MediaStreamConstraints/audio}}"].</li>
           <li>Return |result|.</li>
         </ol>
       </section>
     </section>
 
     <section>
-      <h3>The &lt;<a>usermedia</a>&gt; HTML element</h3>
+      <h3>The [^usermedia^] HTML element</h3>
       <p>
         The &lt;<dfn data-dfn-type="element">usermedia</dfn>&gt; HTML element
         is an [[HTML]] element that can mediate access to a {{MediaStream}}
-        consisting of one or more tracks.
-      </p>
-      <p>
-        The &lt;<a>usermedia</a>&gt; element uses the following
-        <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-dom">DOM interface</a>:
+        consisting of a microphone and camera track.
+        The [^usermedia^] element is {{SecureContext}} restricted. Outside
+        of a [=secure context=] it uses the default [=element interface=].
+        In a [=secure context=] it uses the following [=element interface=]:
       </p>
       <pre class=idl>
       [SecureContext]
@@ -2677,7 +2650,7 @@ onmessage = async ({data: {track}}) => {
       };
       </pre>
 
-      <p>The &lt;<a>usermedia</a>&gt; element uses the following internal slots:</p>
+      <p>The [^usermedia^] element uses the following internal slots:</p>
       <ul>
         <li>
           <dfn data-dfn-for="HTMLUserMediaElement">[[\stream]]</dfn> &mdash;
@@ -2693,7 +2666,7 @@ onmessage = async ({data: {track}}) => {
         </li>
       </ul>
 
-      <p>The &lt;<a>usermedia</a>&gt; element's activation is filtered to allow
+      <p>The [^usermedia^] element's activation is filtered to allow
          only activitations that result from genuine user action. Each activation
          is expected to fire an event on one of three event handlers, depending
          on whether the activation was successful:</p>
@@ -2719,7 +2692,7 @@ onmessage = async ({data: {track}}) => {
       </ul>
 
       <p>
-        The &lt;<a>usermedia</a>&gt; element belongs to the [=flow content=],
+        The [^usermedia^] element belongs to the [=flow content=],
         [=phrasing content=], [=interactive content=], and [=palpable content=]
         <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">categories</a>.
         It can be used in contexts where [=phrasing content=] is expected. Its
@@ -2728,7 +2701,7 @@ onmessage = async ({data: {track}}) => {
       </p>
 
       <p>
-        The &lt;<a>usermedia</a>&gt; element supports the following
+        The [^usermedia^] element supports the following
         <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">content attributes</a>:
       </p>
       <dl>
@@ -2742,9 +2715,9 @@ onmessage = async ({data: {track}}) => {
         <dd>&mdash; [=event handler IDL attributes=]</dd>
       </dl>
 
-      <p>The &lt;<a>usermedia</a>&gt; element's presentation is left to the [=user
+      <p>The [^usermedia^] element's presentation is left to the [=user
         agent=]. It's expected that the presentation is chiefly that of a button,
-        with text and/or an icon to indicate this will give camera and microphone
+        with text and/or an icon to indicate this is managing camera and microphone
         access. The presentation is expected to reflect the state of the underlying
         stream (if any), e.g. by hinting to the user that a stream is live
         (or not), or that the camera and microphone might be active or muted.
@@ -2785,29 +2758,28 @@ onmessage = async ({data: {track}}) => {
         </ol>
 
         <p>
-          The &lt;<a>usermedia</a>&gt; element's [=EventTarget/activation behavior=],
+          The [^usermedia^] element's [=EventTarget/activation behavior=],
           given |event|, is:
         </p>
         <ol class=algorithm>
-          <li>If |event| is not [=HTMLUserMediaElement/trusted=], then
-            [=fire an event=] named `error`, using an "{{InvalidStateError}}"
-            {{DOMException}}.
+          <li>If |event| is not [=AllUserMediaElements/trusted=], then
+            [=AllUserMediaElements/queue an event=] named `error`, using an
+            "{{InvalidStateError}}" {{DOMException}}.
           </li>
           <li>
-            Otherwise, if {{HTMLUserMediaElement/[[stream]]}} is not null, then
+            Otherwise, if {{HTMLUserMediaElement/[[stream]]}} is null, then
             run [=HTMLUserMediaElement/activation start stream=] steps given
             [=this=].
           </li>
         </ol>
 
         <div class=note>
-          &lt;<a>usermedia</a>&gt;'s [=EventTarget/activation behavior=]
+          [^usermedia^]'s [=EventTarget/activation behavior=]
           currently ignores activation when it already has a
           {{HTMLUserMediaElement/[[stream]]}} set. The intent is that an element
-          with an inactive stream will start a new one. And an element with an
-          active stream will act as a toggle to allow users to control the
-          stream. The details still need to be determined.
-        </div>
+          with an ended stream will start a new one. The behaviour for
+          an element with an active stream still need to be determined.
+       </div>
 
 
         <p>The <dfn data-dfn-for="HTMLUserMediaElement">activation start stream</dfn>
@@ -2821,6 +2793,9 @@ onmessage = async ({data: {track}}) => {
             <div class=note>
               The call to the {{MediaDevices/getUserMedia()}} method should
               be replaced with a non-IDL entry point or algorithm.
+              Any such a replacement must have precisely the same side effects
+              on the [[[?RFC8828#section-5.2|mode]]] defined in [[?RFC8828]] as
+              calling the IDL entry point.
             </div>
             <div class=note>
               {{MediaDevices/getUserMedia()}} encourages User Agents
@@ -2851,34 +2826,16 @@ onmessage = async ({data: {track}}) => {
                     call has failed due to user action or inaction, such as a
                     user rejecting or not answering a permission prompt raised
                     by {{MediaDevices/getUserMedia()}}, then
-                    [=fire an event=] named `cancel` on [=this=], using
-                    {{DOMException}}, and return.</li>
+                    [=AllUserMediaElements/queue an event=] named `cancel` on
+                    [=this=], using {{DOMException}}, and return.</li>
                   <li>[=Assert=]: |r| is a |DOMException|.</li>
                   <li>Set {{HTMLUserMediaElement/[[error]]}} to |r|.
                   <li>[=Fire an event=] named `error` on [=this=],
                     using {{DOMException}}. (Description still TBD.).</li>
-                  <li>Return.</li>
                 </ol>
               </li>
             </ol>
           </li>
-        </ol>
-
-        <p>To determine whether an {{Event}} |event| is
-          <dfn data-dfn-for=HTMLUserMediaElement>trusted</dfn>:</p>
-
-        <div class=note>{{HTMLUserMediaElement}} stream creation is supposed to happen by
-          genuine user action. [=User agents=] SHOULD suppress activation
-          for "click-jacking", as well as for programmatic activation. Since
-          exact critera for these are difficult to specify, we presently leave
-          this as implementation defined. [=User agents=] MUST at minimum
-          reject untrusted events.</div>
-
-        <ol class=algorithm>
-          <li>If |event|.{{Event/isTrusted}} is false: Return false.</li>
-          <li>[=User agents=] SHOULD run additional, implementation-defined steps
-            to determine trusted-ness of |event|.</li>
-          <li>Return true.</li>
         </ol>
 
         <p>The <dfn data-dfn-for="HTMLUserMediaElement">track monitor</dfn> steps are:</p>
@@ -2886,20 +2843,21 @@ onmessage = async ({data: {track}}) => {
           <li>[=Assert=]: {{HTMLUserMediaElement/[[stream]]}} is a {{MediaStream}}.</li>
           <li>
             For each |track| in the result of calling {{MediaStream/getTracks()}}
-            on {{HTMLUserMediaElement/[[stream]]}}, the user agent MUST monitor
+            on {{HTMLUserMediaElement/[[stream]]}}, the user agent monitors
             the |track|'s {{MediaStreamTrack/readyState}} (specifically for
             terminations triggered by {{MediaStreamTrack/stop()}}), its
             {{MediaStreamTrack/enabled}} state, and its
             {{MediaStreamTrack/muted}} state.
           </li>
           <li>
-            When the state of any monitored |track| changes, the user agent MUST update the |element|'s
-            internal UI to reflect the active, muted, or ended state of the |track|.
+            When the state of any monitored |track| changes, the user agent
+            updates the |element|'s internal UI to reflect the active, muted,
+            or ended state of the |track|.
           </li>
           <li>
             If {{HTMLUserMediaElement/[[stream]]}}.{{MediaStream/active}}
-            becomes `"ended"`, the user agent MUST reset the |element|'s
-            internal UI to its initial request state.
+            becomes `"ended"`, the user agent reset the |element|'s internal
+            UI to its initial request state.
           </li>
         </ol>
 
@@ -2909,13 +2867,71 @@ onmessage = async ({data: {track}}) => {
         </p>
         <ol class=algorithm>
           <li>Let |result| be a new {{MediaStreamConstraints}} [=dictionary=].</li>
-          <li>If |constraints|["audio"] [=map/exists=], set |result|["audio"] to a copy of |constraints|["audio"]. Otherwise, set |result|["audio"] to an empty [=dictionary=].</li>
-          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["audio"].</li>
-          <li>If |constraints|["video"] [=map/exists=], set |result|["video"] to a copy of |constraints|["video"]. Otherwise, set |result|["video"] to an empty [=dictionary=].</li>
-          <li>Remove any <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a> from |result|["video"].</li>
+          <li>If |constraints|["{{HTMLMediaStreamConstraints/audio}}"]
+            [=map/exists=], set |result|["{{MediaStreamConstraints/audio}}"] to
+            a copy of |constraints|["{{HTMLMediaStreamConstraints/audio}}"].
+            Otherwise, set |result|["{{MediaStreamConstraints/audio}}"] to
+            an empty [=dictionary=].</li>
+          <li>Remove any
+            <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a>
+            from |result|["{{MediaStreamConstraints/audio}}"].</li>
+          <li>If |constraints|["{{HTMLMediaStreamConstraints/video}}"]
+            [=map/exists=], set |result|["{{MediaStreamConstraints/video}}"] to
+            a copy of |constraints|["{{HTMLMediaStreamConstraints/video}}"].
+            Otherwise, set |result|["{{MediaStreamConstraints/video}}"] to an
+            empty [=dictionary=].</li>
+          <li>Remove any
+            <a data-cite="mediacapture-streams#dfn-required-constraints">required constraints</a>
+            from |result|["{{MediaStreamConstraints/video}}"].</li>
           <li>Return |result|.</li>
         </ol>
       </section>
+    </section>
+    <section>
+      <h3>Shared Algorithms</h3>
+
+      <p>To determine whether an {{Event}} |event| is
+        <dfn data-dfn-for=AllUserMediaElements>trusted</dfn>:</p>
+
+      <div class=note>
+        {{HTMLUserMediaElement}} stream creation is supposed to happen by
+        genuine user action. [=User agents=] SHOULD suppress activation
+        for "click-jacking", as well as for programmatic activation. Since
+        exact critera for these are difficult to specify, we presently leave
+        this as implementation defined. [=User agents=] MUST at minimum
+        reject untrusted events.</div>
+
+      <ol class=algorithm>
+        <li>If |event|.{{Event/isTrusted}} is false: Return false.</li>
+        <li>[=User agents=] SHOULD run additional, implementation-defined steps
+          to determine trusted-ness of |event|.
+          <p class=note>Additional implementation guidelines will be
+            provided.</p>
+        </li>
+        <li>Return true.</li>
+      </ol>
+
+    <p>
+      Each user media element described in
+      [[[#media-capture-html-elements]]] has its own
+      [=task source=], the element's
+      <dfn data-dfn-for="AllUserMediaElements">media capture element task source</dfn>.
+    </p>
+
+    <p>
+      To <dfn data-dfn-for="AllUserMediaElements">queue an event</dfn> named
+      |name| on |element|, using an |eventConstructor|:
+      </p>
+      <ol class=algorithm>
+        <li>[=Queue an element task=] on |element|'s
+          [=AllUserMediaElements/media capture element task source=]
+          with |element|, using the following steps:
+          <ol>
+            <li>[=Fire an event=] named |name| at |element|,
+              using |eventConstructor|.</li>
+          </ol>
+        </li>
+      </ol>
     </section>
   </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -2108,10 +2108,12 @@ onmessage = async ({data: {track}}) => {
         [HTMLConstructor] constructor();
 
         readonly attribute MediaStreamTrack? track;
+        readonly attribute DOMException? error;
         undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
 
         attribute EventHandler onstream;
         attribute EventHandler onerror;
+        attribute EventHandler oncancel;
       };
       </pre>
 
@@ -2125,6 +2127,26 @@ onmessage = async ({data: {track}}) => {
           <dfn data-dfn-for="HTMLCameraElement">[[\constraints]]</dfn> &mdash;
           Holds a {{MediaTrackConstraintSet}}.
         </li>
+        <li>
+          <dfn data-dfn-for="HTMLCameraElement">[[\error]]</dfn> &mdash;
+          Holds null or a {{DOMException}}.
+        </li>
+      </ul>
+
+      <p>The &lt;<a>camera</a>&gt; element's activation is filtered to allow
+        only activitations that result from genuine user action. Each activation
+        is expected to fire an event on one of three event handlers, depending
+        on whether the activation was successful:</p>
+
+      <ul>
+        <li><dfn data-dfn-for=HTMLCameraElement>onstream</dfn> &mdash;
+          Activation was successful and a media stream is available.</li>
+        <li><dfn data-dfn-for=HTMLCameraElement>oncancel</dfn> &mdash;
+          Activation was not successful, because the user decided not to proceed.
+          For example, by not accepting a permission prompt.</li>
+        <li><dfn data-dfn-for=HTMLCameraElement>onerror</dfn> &mdash;
+          Activation has failed. No media stream is available. The
+          {{HTMLCameraElement/error}} attribute holds additional information.</li>
       </ul>
 
       <p>
@@ -2164,11 +2186,17 @@ onmessage = async ({data: {track}}) => {
         <ol class=algorithm>
           <li>Initialize [=this=].{{HTMLCameraElement/[[track]]}} to null.</li>
           <li>Initialize [=this=].{{HTMLCameraElement/[[constraints]]}} to «».</li>
+          <li>Initialize [=this=].{{HTMLCameraElement/[[error]]}} to null.</li>
         </ol>
 
         <p>The <dfn data-dfn-for=HTMLCameraElement>track</dfn> <a>getter</a> steps are:</p>
         <ol class=algorithm>
           <li>Return [=this=].{{HTMLCameraElement/[[track]]}}.</li>
+        </ol>
+
+        <p>The <dfn data-dfn-for=HTMLCameraElement>error</dfn> <a>getter</a> steps are:</p>
+        <ol class=algorithm>
+          <li>Return [=this=].{{HTMLCameraElement/[[error]]}}.</li>
         </ol>
 
         <p>
@@ -2238,6 +2266,7 @@ onmessage = async ({data: {track}}) => {
                     <ol>
                       <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
                       <li>[=Assert=]: |r| is a |DOMException|.</li>
+                      <li>Set [=this=].{{HTMLCameraElement/[[error]]}} to |r|.
                       <li>[=Fire an event=] named `error` on [=this=],
                         using {{DOMException}}.
                         (Description still TBD.)</li>
@@ -2248,7 +2277,7 @@ onmessage = async ({data: {track}}) => {
               </li>
             </ol>
           </li>
-          <li>Otherwise, [=fire an event=] named `error` on [=this=],
+          <li>Otherwise, [=fire an event=] named `cancel` on [=this=],
             using {{DOMException}}.
             (Description still TBD.)</li>
         </ol>
@@ -2341,10 +2370,12 @@ onmessage = async ({data: {track}}) => {
         [HTMLConstructor] constructor();
 
         readonly attribute MediaStreamTrack? track;
+        readonly attribute DOMException? error;
         undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
 
         attribute EventHandler onstream;
         attribute EventHandler onerror;
+        attribute EventHandler oncancel;
       };
       </pre>
 
@@ -2358,7 +2389,27 @@ onmessage = async ({data: {track}}) => {
           <dfn data-dfn-for="HTMLMicrophoneElement">[[\constraints]]</dfn> &mdash;
           Holds a {{MediaTrackConstraintSet}}.
         </li>
+        <li>
+          <dfn data-dfn-for="HTMLMicrophoneElement">[[\error]]</dfn> &mdash;
+          Holds null or a {{DOMException}}.
+        </li>
      </ul>
+
+     <p>The &lt;<a>microphone</a>&gt; element's activation is filtered to allow
+        only activitations that result from genuine user action. Each activation
+        is expected to fire an event on one of three event handlers, depending
+        on whether the activation was successful:</p>
+
+      <ul>
+        <li><dfn data-dfn-for=HTMLMicrophoneElement>onstream</dfn> &mdash;
+          Activation was successful and a media stream is available.</li>
+        <li><dfn data-dfn-for=HTMLMicrophoneElement>oncancel</dfn> &mdash;
+          Activation was not successful, because the user decided not to proceed.
+          For example, by not accepting a permission prompt.</li>
+        <li><dfn data-dfn-for=HTMLMicrophoneElement>onerror</dfn> &mdash;
+          Activation has failed. No media stream is available. The
+          {{HTMLMicrophoneElement/error}} attribute holds additional information.</li>
+      </ul>
 
       <p>
         The &lt;<a>microphone</a>&gt; element belongs to the [=flow content=],
@@ -2397,12 +2448,18 @@ onmessage = async ({data: {track}}) => {
         <ol class=algorithm>
           <li>Initialize [=this=].{{HTMLMicrophoneElement/[[track]]}} to null.</li>
           <li>Initialize [=this=].{{HTMLMicrophoneElement/[[constraints]]}} to «».</li>
+          <li>Initialize [=this=].{{HTMLMicrophoneElement/[[error]]}} to null.</li>
         </ol>
 
         <p>The <dfn data-dfn-for=HTMLMicrophoneElement>track</dfn> <a>getter</a>
           steps are:</p>
         <ol class=algorithm>
           <li>Return [=this=].{{HTMLMicrophoneElement/[[track]]}}.</li>
+        </ol>
+
+        <p>The <dfn data-dfn-for=HTMLMicrophoneElement>error</dfn> <a>getter</a> steps are:</p>
+        <ol class=algorithm>
+          <li>Return [=this=].{{HTMLMicrophoneElement/[[error]]}}.</li>
         </ol>
 
         <p>The <dfn data-dfn-for=HTMLMicrophoneElement>setConstraints()</dfn> steps with
@@ -2475,6 +2532,7 @@ onmessage = async ({data: {track}}) => {
                     <ol>
                       <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
                       <li>[=Assert=]: |r| is a |DOMException|.</li>
+                      <li>Set {{HTMLMicrophoneElement/[[error]]}} to |r|.
                       <li>[=Fire an event=] named `error` on [=this=],
                         using {{DOMException}}.
                         (Description still TBD.)</li>
@@ -2485,7 +2543,7 @@ onmessage = async ({data: {track}}) => {
               </li>
             </ol>
           </li>
-          <li>Otherwise, [=fire an event=] named `error` on [=this=],
+          <li>Otherwise, [=fire an event=] named `cancel` on [=this=],
             using {{DOMException}}.
             (Description still TBD.)</li>
         </ol>
@@ -2583,10 +2641,12 @@ onmessage = async ({data: {track}}) => {
         [HTMLConstructor] constructor();
 
         readonly attribute MediaStream? stream;
+        readonly attribute DOMException? error;
         undefined setConstraints(optional HTMLMediaStreamConstraints constraints = {});
 
         attribute EventHandler onstream;
         attribute EventHandler onerror;
+        attribute EventHandler oncancel;
       };
       </pre>
 
@@ -2600,6 +2660,26 @@ onmessage = async ({data: {track}}) => {
           <dfn data-dfn-for="HTMLUserMediaElement">[[\constraints]]</dfn> &mdash;
           Holds an {{HTMLMediaStreamConstraints}}.
         </li>
+        <li>
+          <dfn data-dfn-for="HTMLUserMediaElement">[[\error]]</dfn> &mdash;
+          Holds null or a {{DOMException}}.
+        </li>
+      </ul>
+
+     <p>The &lt;<a>usermedia</a>&gt; element's activation is filtered to allow
+        only activitations that result from genuine user action. Each activation
+        is expected to fire an event on one of three event handlers, depending
+        on whether the activation was successful:</p>
+
+      <ul>
+        <li><dfn data-dfn-for=HTMLUserMediaElement>onstream</dfn> &mdash;
+          Activation was successful and a media stream is available.</li>
+        <li><dfn data-dfn-for=HTMLUserMediaElement>oncancel</dfn> &mdash;
+          Activation was not successful, because the user decided not to proceed.
+          For example, by not accepting a permission prompt.</li>
+        <li><dfn data-dfn-for=HTMLUserMediaElement>onerror</dfn> &mdash;
+          Activation has failed. No media stream is available. The
+          {{HTMLUserMediaElement/error}} attribute holds additional information.</li>
       </ul>
 
       <p>
@@ -2637,14 +2717,21 @@ onmessage = async ({data: {track}}) => {
           steps are:
         </p>
         <ol class=algorithm>
-          <li>Initialize {{HTMLUserMediaElement/[[stream]]}} to null.</li>
-          <li>Initialize {{HTMLUserMediaElement/[[constraints]]}} to «».</li>
+          <li>Initialize [=this=].{{HTMLUserMediaElement/[[stream]]}} to null.</li>
+          <li>Initialize [=this=].{{HTMLUserMediaElement/[[constraints]]}} to «».</li>
+          <li>Initialize [=this=].{{HTMLUserMediaElement/[[error]]}} to null.</li>
         </ol>
 
         <p>The <dfn data-dfn-for=HTMLUserMediaElement>stream</dfn>
           <a>getter</a> steps are:</p>
         <ol class=algorithm>
           <li>Return {{HTMLUserMediaElement/[[stream]]}}.</li>
+        </ol>
+
+        <p>The <dfn data-dfn-for=HTMLUserMediaElement>error</dfn>
+          <a>getter</a> steps are:</p>
+        <ol class=algorithm>
+          <li>Return {{HTMLUserMediaElement/[[error]]}}.</li>
         </ol>
 
         <p>The <dfn data-dfn-for=HTMLUserMediaElement>setConstraints()</dfn>
@@ -2713,6 +2800,7 @@ onmessage = async ({data: {track}}) => {
                     <ol>
                       <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
                       <li>[=Assert=]: |r| is a |DOMException|.</li>
+                      <li>Set {{HTMLUserMediaElement/[[error]]}} to |r|.
                       <li>[=Fire an event=] named `error` on [=this=],
                         using {{DOMException}}. (Description still TBD.).</li>
                       <li>Return.</li>
@@ -2722,7 +2810,7 @@ onmessage = async ({data: {track}}) => {
               </li>
             </ol>
           </li>
-          <li>[=Fire an event=] named `error` on [=this=],
+          <li>[=Fire an event=] named `cancel` on [=this=],
              using {{DOMException}}. (Description still TBD.).
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -2224,17 +2224,11 @@ onmessage = async ({data: {track}}) => {
                   <li>If |mediaPromise| was fulfilled with value |v|:
                     <ol>
                       <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
-                      <li>Let |tracks| be the result of calling {{MediaStream/getVideoTracks()}} on |v|.</li>
-                      <li>If |tracks| is not empty, set
+                      <li>Let |tracks| be the set of {{MediaStreamTrack}}s in
+                        |v|'s [=/track set=] whose {{MediaStreamTrack/[[Kind]]}}
+                        is equal to "video". (Issue: `[[Kind]]` isn't exported.)</li>
+                      <li>Set
                         {{HTMLCameraElement/[[track]]}} to |tracks|[0].</li>
-                      <li>If {{HTMLCameraElement/[[track]]}} is null:
-                        <ol>
-                          <li>[=Fire an event=] named `error` on [=this=],
-                            using {{DOMException}}.
-                            (Description still TBD.)</li>
-                          <li>Return.</li>
-                        </ol>
-                      </li>
                       <li>Run the [=HTMLCameraElement/track monitor=] steps on [=this=].</li>
                       <li>[=Fire an event=] named `stream` on [=this=].</li>
 
@@ -2469,17 +2463,11 @@ onmessage = async ({data: {track}}) => {
                   <li>If |mediaPromise| was fulfilled with value |v|:
                     <ol>
                       <li>[=Assert=]: |v| is a {{MediaStream}}.</li>
-                      <li>Let |tracks| be the result of calling {{MediaStream/getAudioTracks()}} on |v|.</li>
-                      <li>If |tracks| is not empty, set
+                      <li>Let |tracks| be the set of {{MediaStreamTrack}}s in
+                        |v|'s [=/track set=] whose {{MediaStreamTrack/[[Kind]]}}
+                        is equal to "audio".</li>
+                      <li>Set
                         {{HTMLMicrophoneElement/[[track]]}} to |tracks|[0].</li>
-                      <li>If {{HTMLMicrophoneElement/[[track]]}} is null:
-                        <ol>
-                          <li>[=Fire an event=] named `error` on [=this=],
-                            using {{DOMException}}.
-                            (Description still TBD.)</li>
-                          <li>Return.</li>
-                        </ol>
-                      </li>
                       <li>Run the [=HTMLMicrophoneElement/track monitor=] steps on [=this=].</li>
                       <li>[=Fire an event=] named `stream` on [=this=].</li>
 

--- a/index.html
+++ b/index.html
@@ -1695,7 +1695,7 @@ partial dictionary MediaTrackSupportedConstraints {
   boolean humanFaceDetectionMode = true;
 };</pre>
       <section class="notoc">
-        <h4>Dictionary {{MediaTrackSupportedConstraints}} Members</h4>
+        <h3>Dictionary {{MediaTrackSupportedConstraints}} Members</h3>
         <dl class="dictionary-members" data-dfn-for="MediaTrackSupportedConstraints" data-link-for="MediaTrackSupportedConstraints">
           <dt><dfn>humanFaceDetectionMode</dfn> of type {{boolean}}, defaulting to <code>true</code></dt>
             <dd>See <a href=
@@ -1711,7 +1711,7 @@ partial dictionary MediaTrackCapabilities {
   sequence&lt;DOMString&gt; humanFaceDetectionMode;
 };</pre>
       <section class="notoc">
-        <h4>Dictionary {{MediaTrackCapabilities}} Members</h4>
+        <h3>Dictionary {{MediaTrackCapabilities}} Members</h3>
         <dl class="dictionary-members" data-dfn-for="MediaTrackCapabilities" data-link-for="MediaTrackCapabilities">
           <dt><dfn>humanFaceDetectionMode</dfn> of type <code>sequence&lt;{{DOMString}}&gt;</code></dt>
           <dd>
@@ -1730,13 +1730,12 @@ partial dictionary MediaTrackConstraintSet {
   ConstrainDOMString humanFaceDetectionMode;
 };</pre>
       <section class="notoc">
-        <h4>Dictionary {{MediaTrackConstraintSet}} Members</h4>
+        <h3>Dictionary {{MediaTrackConstraintSet}} Members</h3>
         <dl class="dictionary-members" data-dfn-for="MediaTrackConstraintSet" data-link-for="MediaTrackConstraintSet">
           <dt><dfn>humanFaceDetectionMode</dfn> of type {{ConstrainDOMString}}</dt>
           <dd>See <a href=
             "#def-constraint-humanFaceDetectionMode">
             humanFaceDetectionMode</a> for details.</dd>
-          </dd>
         </dl>
       </section>
     </section>
@@ -1747,13 +1746,12 @@ partial dictionary MediaTrackSettings {
   DOMString humanFaceDetectionMode;
 };</pre>
       <section class="notoc">
-        <h4>Dictionary {{MediaTrackSettings}} Members</h4>
+        <h3>Dictionary {{MediaTrackSettings}} Members</h3>
         <dl class="dictionary-members" data-dfn-for="MediaTrackSettings" data-link-for="MediaTrackSettings">
           <dt><dfn>humanFaceDetectionMode</dfn> of type {{DOMString}}</dt>
           <dd>See <a href=
             "#def-constraint-humanFaceDetectionMode">
             humanFaceDetectionMode</a> for details.</dd>
-          </dd>
         </dl>
       </section>
     </section>
@@ -1766,7 +1764,7 @@ enum HumanFaceDetectionModeEnum {
   "bounding-box-with-landmark-center-point",
 };</pre>
       <section class="notoc">
-        <h4>{{HumanFaceDetectionModeEnum}} Enumeration Description</h4>
+        <h3>{{HumanFaceDetectionModeEnum}} Enumeration Description</h3>
         <dl data-dfn-for="HumanFaceDetectionModeEnum" data-link-for="HumanFaceDetectionModeEnum">
           <dt><dfn><code>none</code></dfn></dt>
           <dd>
@@ -2235,7 +2233,7 @@ onmessage = async ({data: {track}}) => {
 
                     </ol>
                   </li>
-                  <li>Otherwise:</li>
+                  <li>Otherwise:
                     <ol>
                       <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
                       <li>[=Assert=]: |r| is a |DOMException|.</li>
@@ -2473,7 +2471,7 @@ onmessage = async ({data: {track}}) => {
 
                     </ol>
                   </li>
-                  <li>Otherwise:</li>
+                  <li>Otherwise:
                     <ol>
                       <li>[=Assert=]: |mediaPromise| was rejected with reason |r|.</li>
                       <li>[=Assert=]: |r| is a |DOMException|.</li>
@@ -2731,7 +2729,7 @@ onmessage = async ({data: {track}}) => {
 
         <p>
           The &lt;<a>usermedia</a>&gt; element's
-          <dfn for=HTMLUserMediaElement>activation second</dfn> steps are:
+          <dfn data-dfn-for="HTMLUserMediaElement">activation second</dfn> steps are:
         </p>
         <ol class=algorithm>
           <li>[=Assert=]: [=this=].{{HTMLUserMediaElement/[[stream]]}} is a

--- a/media-capture-elements-explainer.md
+++ b/media-capture-elements-explainer.md
@@ -1,4 +1,4 @@
-# Media Capture Elements: `<usermedia>`, `<camera>`, and `<microphone>`
+# Media Capture Elements: `<camera>`, `<microphone>`, and `<usermedia>`
 
 ## Authors:
 
@@ -12,244 +12,149 @@ The web permission model is shifting from passive permission control to active C
 
 Rather than serving as a static status indicator, a Capability Element acts as a functional action broker. It streamlines the entire lifecycle: establishing a trusted signal of intent, managing the permission flow, and delivering the resulting data or media stream directly to the application. This shift reduces developer friction, eliminates "permission holes," and provides users with a consistent, browser-controlled interface for hardware like cameras and microphones.
 
-This document proposes a suite of targeted Media Capture Elements (`<usermedia>`, `<camera>`, and `<microphone>`). They move beyond acting merely as permission gatekeepers to serving as data mediators: handling consent, fetching the `MediaStream`, delivering it to the site, and persisting as a stateful, trusted UI control for toggling media tracks.
+This document proposes a suite of targeted Media Capture Elements (`<camera>`, `<microphone>`, and `<usermedia>`). They move beyond acting merely as permission gatekeepers to serving as data mediators: handling consent, fetching the `MediaStream`, delivering it to the site, and persisting as a stateful, trusted UI control for toggling media tracks.
 
 ## Goals
 
 *   Data Mediator and Action Broker: The elements handle the entire acquisition flow: obtaining user consent, executing the underlying `getUserMedia` request, and exposing the resulting `MediaStream` directly, often eliminating the need for separate JavaScript API boilerplate.
-*   Stateful Media Capture Control: Elements act as integrated UI components. Following a permission grant, the element transitions from a "request" state to a "control" state. For `<camera>` and `<microphone>`, this provides a browser-enforced, trusted UI toggle for muting and unmuting the stream. All elements act as strict monitors of their assigned track's states, natively reverting to the "request" state if the underlying tracks are fully terminated.
-*   Reduced Friction & Trusted Intent: Establish a "trusted signal of intent" driven by explicit User Gestures on a browser-controlled element, allowing developers to offer users an option to use the grant and use the capability in context.
-*   Seamless In-Page Recovery: Similar to and inheriting concepts from the `<permission>` element, this resolves the "permission hole" by providing an in-page flow to re-enable access if the user previously denied it, avoiding the need for users to navigate complex, UA-specific browser settings.
+*   Stateful Media Capture Control: Elements act as integrated UI components. Following a permission grant, the element transitions from a _request_ state to a _control_ state. For `<camera>` and `<microphone>`, this provides a browser-enforced, UI toggle for disabling and enabling the underlying track. All elements reflect their track's enabled state, and revert to the _request_ state once the track has ended.
+*   Reduced Friction & Trusted Intent: Establish a "trusted signal of intent" driven by explicit User Gestures on a browser-controlled element, allowing developers to offer users the option to use the capability in context without having to deal with permission.
+*   Seamless In-Page Recovery: Similar to and inheriting concepts from the `<permission>` element, this resolves the "permission hole" by providing an in-page flow to re-enable access if the user previously blocked it in the user agent, avoiding the need for users to navigate complex, UA-specific browser settings.
 *   Specific vs. Generic Tags: Replace the generic `<permission>` element with targeted, semantic elements (`<camera>`, `<microphone>`, `<usermedia>`). This allows for UA-tailored UI, specific IDL attributes, and distinct security/privacy models tailored to the specific hardware media capture capability.
 
 ## Non-goals
 
-*   Replacing `getUserMedia`: The `mediaDevices.getUserMedia` API remains the primary programmatic primitive. Media Capture Elements are designed to complement it by handling common UI-driven flows. In the future, we may add a parameter to indicate whether the `getUserMedia` request originated from a programmatic JS call or directly from a media capture element.
+*   Replacing `getUserMedia`: The `mediaDevices.getUserMedia` API remains the primary programmatic primitive. Media Capture Elements are designed to complement it by handling common UI-driven flows.
+*   The `permissions` API will remain to support the use of `getUserMedia` alongside the new elements.
 *   Complete UI Customization: The shadow DOM/internal UI of these elements is strictly controlled by the UA to prevent clickjacking and ensure a trusted state representation. Complete visual overriding by the site is a non-goal for security reasons.
 
 ## The `<camera>` HTML element
 
-The `<camera>` element provides a dedicated UI for requesting and controlling access to a camera's video track. It renders as a camera text button or icon. After a successful grant, the element transitions to a trusted UI toggle for muting and unmuting the video stream.
+The `<camera>` element provides a dedicated UI for requesting and controlling access to a camera's video track. It renders as a camera text button or icon. After a successful grant, the element transitions to a trusted UI toggle for disabling and enabling the video track.
 
-### WebIDL
 
-```webidl
-[Exposed=Window]
-interface HTMLCameraElement : HTMLElement {
-  [HTMLConstructor] constructor();
-
-  readonly attribute MediaStreamTrack? track;
-  undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
-  readonly attribute any error;
-
-  attribute boolean autostart;
-
-  attribute EventHandler onstream;
-  attribute EventHandler ontrackchange;
-};
-HTMLCameraElement includes ActivationBlockersMixin;
-HTMLCameraElement includes PowerfulFeatureObserver;
-```
 
 ### Attributes and Properties
 
 *   `track`: A read-only property that holds the associated `MediaStreamTrack` object (video). It is populated automatically upon successful user interaction.
 *   `autostart`: A boolean attribute. If present, the UA will attempt to start the stream automatically as the element is added to the DOM and rendered (provided permissions are already granted).
-*   `error`: A read-only property that holds a `DOMException` or `null`. Populated if the stream acquisition fails.
-*   `onstream`: An `EventHandler` that fires when a `getUserMedia` attempt finishes (either populating `track` or `error`).
-*   `ontrackchange`: An `EventHandler` that fires when the associated track's active/muted/ended state changes.
-*   `isValid`, `invalidReason`, `onvalidationstatuschange`: Provided by the `ActivationBlockersMixin` to protect against programmatic activation and clickjacking.
-*   `onpromptaction`, `onpromptdismiss`: Provided by the `PowerfulFeatureObserver` to monitor permission prompts.
+*   `onstream`: An `EventHandler` that fires when a hardware acquisition attempt completes successfully and populates the `track` property.
+*   `onerror`: An `EventHandler` that fires when a stream acquisition attempt fails. To allow the element to carry detailed diagnostic info without bloating the main element interface, it is proposed that this event object carries a dedicated error payload containing, for example, a DOMException along with optional platform-specific diagnostic parameters.
 
 ### Constraints Configuration
 
 Developers can specify a `MediaTrackConstraintSet` to dictate the parameters of the underlying `getUserMedia` call. This is done imperatively via the `setConstraints()` method. If constraints are not set before the user interacts with the element, an empty default (`{}`) is used.
 
-**Constraint Filtering**: The UA applies a "constraint filter" before executing the `getUserMedia` call. Because the element's `setConstraints()` takes a `MediaTrackConstraintSet` directly (which contains no `audio` or `video` keys), the UA constructs a `MediaStreamConstraints` object where `audio` is forced to `false`, and `video` is set to the provided `MediaTrackConstraintSet`. Additionally, any required constraints (like `exact`, `min`, or `max`) are stripped to prevent the element from failing silently with an `OverconstrainedError` when the user interacts with it.
+**Constraint Filtering**: Sets the active constraints for the underlying camera track. Note that advanced and required constraints are ignored by the User Agent to prevent the element from failing silently with an `OverconstrainedError`.
 
 ### Example
 
-```html
-<!-- A camera element that will be configured via JavaScript -->
-<camera id="my-camera"></camera>
-<video id="camera-playback" autoplay playsinline></video>
+```javascript
+const cameraEl = document.querySelector('camera');
+const videoEl = document.querySelector('video');
 
-<script>
-  const cameraEl = document.getElementById('my-camera');
-  const videoEl = document.getElementById('camera-playback');
+// Configure high-resolution constraints directly
+cameraEl.setConstraints({ width: 1920, height: 1080 });
 
-  // The developer configures high-resolution video constraints for the camera element
-  cameraEl.setConstraints({
-    width: { ideal: 1920 }, height: { ideal: 1080 }
-  });
+// Handle successful stream acquisition
+cameraEl.addEventListener("stream", () => {
+  const stream = new MediaStream([cameraEl.track]);
+  videoEl.srcObject = stream;
+});
 
-  // Listen for the stream event which fires when acquisition finishes
-  cameraEl.addEventListener("stream", () => {
-    if (cameraEl.track) {
-      // Create a MediaStream from the track to attach to the video element
-      const stream = new MediaStream([cameraEl.track]);
-      videoEl.srcObject = stream;
-    } else if (cameraEl.error) {
-      console.error("Stream acquisition failed:", cameraEl.error);
-    }
-  });
-
-  // Observe the trackchange event to react to mute/unmute state changes
-  cameraEl.addEventListener("trackchange", () => {
-    console.log("Track active/muted/ended state changed");
-  });
-</script>
+// Handle stream acquisition failure with detailed error event diagnostics
+cameraEl.addEventListener("error", (event) => {
+  const exception = event.detail?.exception; // Proposed error dictionary payload
+  console.error(`Camera acquisition failed: ${exception.name}`);
+});
 ```
 
 ## The `<microphone>` HTML element
 
 The `<microphone>` element provides a dedicated UI for requesting and controlling access to a microphone's audio track. It renders as a microphone text button or icon. After a successful grant, the element transitions to a trusted UI toggle for muting and unmuting the audio stream.
 
-### WebIDL
 
-```webidl
-[Exposed=Window]
-interface HTMLMicrophoneElement : HTMLElement {
-  [HTMLConstructor] constructor();
-
-  readonly attribute MediaStreamTrack? track;
-  undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
-  readonly attribute any error;
-
-  attribute boolean autostart;
-
-  attribute EventHandler onstream;
-  attribute EventHandler ontrackchange;
-};
-HTMLMicrophoneElement includes ActivationBlockersMixin;
-HTMLMicrophoneElement includes PowerfulFeatureObserver;
-```
 
 ### Attributes and Properties
 
 *   `track`: A read-only property that holds the associated `MediaStreamTrack` object (audio). It is populated automatically upon successful user interaction.
 *   `autostart`: A boolean attribute. If present, the UA will attempt to start the stream automatically as the element is added to the DOM and rendered (provided permissions are already granted).
-*   `error`: A read-only property that holds a `DOMException` or `null`. Populated if the stream acquisition fails.
-*   `onstream`: An `EventHandler` that fires when a `getUserMedia` attempt finishes (either populating `track` or `error`).
-*   `ontrackchange`: An `EventHandler` that fires when the associated track's active/muted/ended state changes.
-*   `isValid`, `invalidReason`, `onvalidationstatuschange`: Provided by the `ActivationBlockersMixin` to protect against programmatic activation and clickjacking.
-*   `onpromptaction`, `onpromptdismiss`: Provided by the `PowerfulFeatureObserver` to monitor permission prompts.
+*   `onstream`: An `EventHandler` that fires when a hardware acquisition attempt completes successfully and populates the `track` property.
+*   `onerror`: An `EventHandler` that fires when a stream acquisition attempt fails. To allow the element to carry detailed diagnostic info without bloating the main element interface, it is proposed that this event object carries a dedicated error payload containing, for example, a DOMException along with optional platform-specific diagnostic parameters.
 
 ### Constraints Configuration
 
 Developers can specify a `MediaTrackConstraintSet` to dictate the parameters of the underlying `getUserMedia` call. This is done imperatively via the `setConstraints()` method. If constraints are not set before the user interacts with the element, an empty default (`{}`) is used.
 
-**Constraint Filtering**: The UA applies a "constraint filter" before executing the `getUserMedia` call. Because the element's `setConstraints()` takes a `MediaTrackConstraintSet` directly (which contains no `audio` or `video` keys), the UA constructs a `MediaStreamConstraints` object where `video` is forced to `false`, and `audio` is set to the provided `MediaTrackConstraintSet`. Additionally, any required constraints are stripped to prevent the element from failing silently with an `OverconstrainedError`.
+**Constraint Filtering**: Sets the active constraints for the underlying microphone track. Note that advanced and required constraints are ignored by the User Agent to prevent the element from failing silently with an `OverconstrainedError`.
 
 ### Example
 
-```html
-<!-- A microphone element that will be configured via JavaScript -->
-<microphone id="my-microphone"></microphone>
+```javascript
+const micEl = document.querySelector('microphone');
 
-<script>
-  const micEl = document.getElementById('my-microphone');
+// Configure echo cancellation and noise suppression
+micEl.setConstraints({ echoCancellation: true, noiseSuppression: true });
 
-  // The developer configures audio constraints for the microphone element
-  micEl.setConstraints({
-    echoCancellation: true,
-    noiseSuppression: true
-  });
+// Handle successful microphone track acquisition
+micEl.addEventListener("stream", () => {
+  console.log("Audio track successfully acquired:", micEl.track);
+});
 
-  micEl.addEventListener("stream", () => {
-    if (micEl.track) {
-      console.log("Audio track acquired!");
-    } else if (micEl.error) {
-      console.error("Audio acquisition failed:", micEl.error);
-    }
-  });
-</script>
+// Handle acquisition failure
+micEl.addEventListener("error", (event) => {
+  console.error("Audio acquisition failed:", event.detail?.exception.name);
+});
 ```
 
 ## The `<usermedia>` HTML element
 
 The `<usermedia>` element controls combined audio and video capture. Unlike `<camera>` and `<microphone>`, it does not natively transition into a per-track mute/unmute control upon grant due to the complexity of managing potentially independent active/ended states for multiple audio and video tracks. It primarily functions as a unified access broker.
 
-### WebIDL
 
-```webidl
-dictionary HTMLMediaStreamConstraints {
-  MediaTrackConstraintSet video;
-  MediaTrackConstraintSet audio;
-};
-
-[Exposed=Window]
-interface HTMLUserMediaElement : HTMLElement {
-  [HTMLConstructor] constructor();
-
-  readonly attribute MediaStream? stream;
-  undefined setConstraints(optional HTMLMediaStreamConstraints constraints = {});
-  readonly attribute any error;
-
-  attribute boolean autostart;
-
-  attribute EventHandler onstream;
-  attribute EventHandler ontrackchange;
-};
-HTMLUserMediaElement includes ActivationBlockersMixin;
-HTMLUserMediaElement includes PowerfulFeatureObserver;
-```
 
 ### Attributes and Properties
 
 *   `stream`: A read-only property that holds the associated `MediaStream` object. It is populated automatically upon successful user interaction.
 *   `autostart`: A boolean attribute. If present, the UA will attempt to start the stream automatically as the element is added to the DOM and rendered (provided permissions are already granted).
-*   `error`: A read-only property that holds a `DOMException` or `null`. Populated if the stream acquisition fails.
-*   `onstream`: An `EventHandler` that fires when a `getUserMedia` attempt finishes (either populating `stream` or `error`).
-*   `ontrackchange`: An `EventHandler` that fires when the associated tracks' active/muted/ended states change.
-*   `isValid`, `invalidReason`, `onvalidationstatuschange`: Provided by the `ActivationBlockersMixin` to protect against programmatic activation and clickjacking.
-*   `onpromptaction`, `onpromptdismiss`: Provided by the `PowerfulFeatureObserver` to monitor permission prompts.
+*   `onstream`: An `EventHandler` that fires when a hardware acquisition attempt completes successfully and populates the `stream` property.
+*   `onerror`: An `EventHandler` that fires when a stream acquisition attempt fails. To allow the element to carry detailed diagnostic info without bloating the main element interface, it is proposed that this event object carries a dedicated error payload containing, for example, a DOMException along with optional platform-specific diagnostic parameters.
 
 ### Constraints Configuration
 
 Developers can specify `HTMLMediaStreamConstraints` to dictate the parameters of the underlying `getUserMedia` call. This is done imperatively via the `setConstraints()` method. If constraints are not set before the user interacts with the element, a secure default (`{audio:{}, video:{}}`) is used.
 
-**Constraint Filtering**: The UA applies a "constraint filter" before executing the `getUserMedia` call. For `<usermedia>`, the UA constructs a `MediaStreamConstraints` object by extracting the `audio` and `video` `MediaTrackConstraintSet`s from the provided `HTMLMediaStreamConstraints`. If either is omitted, an empty constraint set (`{}`) is substituted, ensuring both audio and video are always requested. Additionally, any required constraints are stripped to prevent silent `OverconstrainedError` failures.
+**Constraint Filtering**: Sets the active constraints for both the underlying audio and video tracks. Note that advanced and required constraints are ignored by the User Agent to prevent the element from failing silently with an `OverconstrainedError`.
 
 ### Example
 
-```html
-<!-- A usermedia element that will be configured via JavaScript -->
-<usermedia id="my-usermedia"></usermedia>
-<video id="stream-playback" autoplay playsinline></video>
+```javascript
+const umElement = document.querySelector('usermedia');
+const videoEl = document.querySelector('video');
 
-<script>
-  const umElement = document.getElementById("my-usermedia");
-  const videoEl = document.getElementById("stream-playback");
+// Configure constraints for combined audio/video capture
+umElement.setConstraints({
+  video: { width: 1280 },
+  audio: {}
+});
 
-  // Configure specific video bounds using setConstraints()
-  umElement.setConstraints({
-    video: { width: { ideal: 1280 } },
-    audio: {}
-  });
+// Handle successful stream acquisition
+umElement.addEventListener("stream", () => {
+  videoEl.srcObject = umElement.stream;
+});
 
-  // Listen for the stream event which fires when acquisition finishes
-  umElement.addEventListener("stream", () => {
-    if (umElement.stream) {
-      videoEl.srcObject = umElement.stream;
-    } else if (umElement.error) {
-      console.error("Stream acquisition failed:", umElement.error);
-    }
-  });
-
-  // Observe the trackchange event to react to mute/unmute state changes
-  umElement.addEventListener("trackchange", () => {
-    console.log("Track active/muted/ended state changed");
-  });
-</script>
+// Handle stream acquisition failure
+umElement.addEventListener("error", (event) => {
+  console.error("Combined stream acquisition failed:", event.detail?.exception.name);
+});
 ```
 
 ## User Journey & Interaction Model
 
 1.  Request State (Inactive): An element with no active associated `MediaStream` is in a request state. A User Gesture (click) triggers a permission prompt (if not already granted). Alternatively, if the `autostart` attribute is present when the element is rendered in the DOM, the UA will attempt to bypass the click requirement and automatically start the stream (provided permissions are already granted).
-2.  Acquisition: Upon grant, the UA implicitly executes a `getUserMedia` request using the element's configured constraints. The resulting `MediaStream` is assigned to the `stream` property. If acquisition fails, the `error` property is populated. The element fires the `stream` event and begins monitoring the resulting `MediaStreamTrack`s.
+2.  Acquisition: Upon grant, the UA implicitly executes a `getUserMedia` request using the element's configured constraints. The resulting track or stream is assigned to the `track` or `stream` property. If acquisition succeeds, the element fires the `stream` event and begins monitoring the resulting `MediaStreamTrack`s. If acquisition fails, the element fires the `error` event carrying detailed payload diagnostics.
 3.  Control State (Active for `<camera>` and `<microphone>` only): The element updates its internal UI (e.g., from "Use Camera" to "Mute Camera"). Subsequent clicks on `<camera>` or `<microphone>` elements will trigger the element's secondary activation steps, natively toggling the `enabled` property of all associated `MediaStreamTrack`s. The `<usermedia>` element skips this second-click behavior due to the complexity of managing potentially independent active/ended states for multiple audio and video tracks.
-4.  Track Monitoring: The element acts as an active monitor for its internal `stream`, observing the `enabled`, `muted`, and `ended` states (including manual `track.stop()` calls) of the associated tracks to ensure its UI remains securely synchronized with the underlying hardware state. Any state changes will update the element's UI and fire the `trackchange` event. If all tracks terminate (i.e. the stream becomes inactive), the element resets to its initial request state, and a subsequent click will fetch a new stream.
+4.  Track Monitoring: The element acts as an active monitor for its internal tracks or streams, observing their `enabled`, `muted`, and `ended` states (including manual `track.stop()` calls) to ensure its UI remains securely synchronized with the underlying hardware state. Any state changes will update the element's UI. If all tracks terminate, the element resets to its initial request state, and a subsequent click will fetch a new stream.
 
 ## Key Scenarios
 

--- a/media-capture-elements-explainer.md
+++ b/media-capture-elements-explainer.md
@@ -48,6 +48,7 @@ interface HTMLCameraElement : HTMLElement {
   attribute EventHandler ontrackchange;
 };
 HTMLCameraElement includes ActivationBlockersMixin;
+HTMLCameraElement includes PowerfulFeatureObserver;
 ```
 
 ### Attributes and Properties
@@ -58,6 +59,7 @@ HTMLCameraElement includes ActivationBlockersMixin;
 *   `onstream`: An `EventHandler` that fires when a `getUserMedia` attempt finishes (either populating `track` or `error`).
 *   `ontrackchange`: An `EventHandler` that fires when the associated track's active/muted/ended state changes.
 *   `isValid`, `invalidReason`, `onvalidationstatuschange`: Provided by the `ActivationBlockersMixin` to protect against programmatic activation and clickjacking.
+*   `onpromptaction`, `onpromptdismiss`: Provided by the `PowerfulFeatureObserver` to monitor permission prompts.
 
 ### Constraints Configuration
 
@@ -120,6 +122,7 @@ interface HTMLMicrophoneElement : HTMLElement {
   attribute EventHandler ontrackchange;
 };
 HTMLMicrophoneElement includes ActivationBlockersMixin;
+HTMLMicrophoneElement includes PowerfulFeatureObserver;
 ```
 
 ### Attributes and Properties
@@ -130,6 +133,7 @@ HTMLMicrophoneElement includes ActivationBlockersMixin;
 *   `onstream`: An `EventHandler` that fires when a `getUserMedia` attempt finishes (either populating `track` or `error`).
 *   `ontrackchange`: An `EventHandler` that fires when the associated track's active/muted/ended state changes.
 *   `isValid`, `invalidReason`, `onvalidationstatuschange`: Provided by the `ActivationBlockersMixin` to protect against programmatic activation and clickjacking.
+*   `onpromptaction`, `onpromptdismiss`: Provided by the `PowerfulFeatureObserver` to monitor permission prompts.
 
 ### Constraints Configuration
 
@@ -188,6 +192,7 @@ interface HTMLUserMediaElement : HTMLElement {
   attribute EventHandler ontrackchange;
 };
 HTMLUserMediaElement includes ActivationBlockersMixin;
+HTMLUserMediaElement includes PowerfulFeatureObserver;
 ```
 
 ### Attributes and Properties
@@ -198,6 +203,7 @@ HTMLUserMediaElement includes ActivationBlockersMixin;
 *   `onstream`: An `EventHandler` that fires when a `getUserMedia` attempt finishes (either populating `stream` or `error`).
 *   `ontrackchange`: An `EventHandler` that fires when the associated tracks' active/muted/ended states change.
 *   `isValid`, `invalidReason`, `onvalidationstatuschange`: Provided by the `ActivationBlockersMixin` to protect against programmatic activation and clickjacking.
+*   `onpromptaction`, `onpromptdismiss`: Provided by the `PowerfulFeatureObserver` to monitor permission prompts.
 
 ### Constraints Configuration
 

--- a/media-capture-elements-explainer.md
+++ b/media-capture-elements-explainer.md
@@ -16,7 +16,7 @@ This document proposes a suite of targeted Media Capture Elements (`<camera>`, `
 
 ## Goals
 
-*   Data Mediator and Action Broker: The elements handle the entire acquisition flow: obtaining user consent, executing the underlying `getUserMedia` request, and exposing the resulting `MediaStream` directly, often eliminating the need for separate JavaScript API boilerplate.
+*   Data Mediator and Action Broker: The elements handle the entire acquisition flow: obtaining user consent, executing the underlying `getUserMedia` request, and exposing the resulting video and/or audio `MediaStreamTrack`s directly, often eliminating the need for separate JavaScript API boilerplate.
 *   Stateful Media Capture Control: Elements act as integrated UI components. Following a permission grant, the element transitions from a _request_ state to a _control_ state. For `<camera>` and `<microphone>`, this provides a browser-enforced, UI toggle for disabling and enabling the underlying track. All elements reflect their track's enabled state, and revert to the _request_ state once the track has ended.
 *   Reduced Friction & Trusted Intent: Establish a "trusted signal of intent" driven by explicit User Gestures on a browser-controlled element, allowing developers to offer users the option to use the capability in context without having to deal with permission.
 *   Seamless In-Page Recovery: Similar to and inheriting concepts from the `<permission>` element, this resolves the "permission hole" by providing an in-page flow to re-enable access if the user previously blocked it in the user agent, avoiding the need for users to navigate complex, UA-specific browser settings.

--- a/media-capture-elements-explainer.md
+++ b/media-capture-elements-explainer.md
@@ -36,10 +36,12 @@ The `<camera>` element provides a dedicated UI for requesting and controlling ac
 
 ### Attributes and Properties
 
-*   `track`: A read-only property that holds the associated `MediaStreamTrack` object (video). It is populated automatically upon successful user interaction.
+*   `track`: A property that holds the associated `MediaStreamTrack` object (video). It is populated automatically upon successful user interaction.
+*   `error`: A property that holds a `DOMException` or `null`. Populated if stream acquisition fails.
 *   `autostart`: A boolean attribute. If present, the UA will attempt to start the stream automatically as the element is added to the DOM and rendered (provided permissions are already granted).
-*   `onstream`: An `EventHandler` that fires when a hardware acquisition attempt completes successfully and populates the `track` property.
-*   `onerror`: An `EventHandler` that fires when a stream acquisition attempt fails. To allow the element to carry detailed diagnostic info without bloating the main element interface, it is proposed that this event object carries a dedicated error payload containing, for example, a DOMException along with optional platform-specific diagnostic parameters.
+*   `ontrack`: An `EventHandler` that fires when a hardware acquisition attempt completes successfully and populates the `track` property.
+*   `onerror`: An `EventHandler` that fires when a stream acquisition attempt fails. See Error Handling below for details.
+*   `oncancel`: An `EventHandler` that fires when the user cancels or dismisses the permission prompt during acquisition.
 
 ### Constraints Configuration
 
@@ -51,22 +53,9 @@ Developers can specify a `MediaTrackConstraintSet` to dictate the parameters of 
 
 ```javascript
 const cameraEl = document.querySelector('camera');
-const videoEl = document.querySelector('video');
 
 // Configure high-resolution constraints directly
 cameraEl.setConstraints({ width: 1920, height: 1080 });
-
-// Handle successful stream acquisition
-cameraEl.addEventListener("stream", () => {
-  const stream = new MediaStream([cameraEl.track]);
-  videoEl.srcObject = stream;
-});
-
-// Handle stream acquisition failure with detailed error event diagnostics
-cameraEl.addEventListener("error", (event) => {
-  const exception = event.detail?.exception; // Proposed error dictionary payload
-  console.error(`Camera acquisition failed: ${exception.name}`);
-});
 ```
 
 ## The `<microphone>` HTML element
@@ -77,10 +66,12 @@ The `<microphone>` element provides a dedicated UI for requesting and controllin
 
 ### Attributes and Properties
 
-*   `track`: A read-only property that holds the associated `MediaStreamTrack` object (audio). It is populated automatically upon successful user interaction.
+*   `track`: A property that holds the associated `MediaStreamTrack` object (audio). It is populated automatically upon successful user interaction.
+*   `error`: A property that holds a `DOMException` or `null`. Populated if stream acquisition fails.
 *   `autostart`: A boolean attribute. If present, the UA will attempt to start the stream automatically as the element is added to the DOM and rendered (provided permissions are already granted).
-*   `onstream`: An `EventHandler` that fires when a hardware acquisition attempt completes successfully and populates the `track` property.
-*   `onerror`: An `EventHandler` that fires when a stream acquisition attempt fails. To allow the element to carry detailed diagnostic info without bloating the main element interface, it is proposed that this event object carries a dedicated error payload containing, for example, a DOMException along with optional platform-specific diagnostic parameters.
+*   `ontrack`: An `EventHandler` that fires when a hardware acquisition attempt completes successfully and populates the `track` property.
+*   `onerror`: An `EventHandler` that fires when a stream acquisition attempt fails. See Error Handling below for details.
+*   `oncancel`: An `EventHandler` that fires when the user cancels or dismisses the permission prompt during acquisition.
 
 ### Constraints Configuration
 
@@ -95,16 +86,6 @@ const micEl = document.querySelector('microphone');
 
 // Configure echo cancellation and noise suppression
 micEl.setConstraints({ echoCancellation: true, noiseSuppression: true });
-
-// Handle successful microphone track acquisition
-micEl.addEventListener("stream", () => {
-  console.log("Audio track successfully acquired:", micEl.track);
-});
-
-// Handle acquisition failure
-micEl.addEventListener("error", (event) => {
-  console.error("Audio acquisition failed:", event.detail?.exception.name);
-});
 ```
 
 ## The `<usermedia>` HTML element
@@ -115,10 +96,12 @@ The `<usermedia>` element controls combined audio and video capture. Unlike `<ca
 
 ### Attributes and Properties
 
-*   `stream`: A read-only property that holds the associated `MediaStream` object. It is populated automatically upon successful user interaction.
+*   `stream`: A property that holds the associated `MediaStream` object. It is populated automatically upon successful user interaction.
+*   `error`: A property that holds a `DOMException` or `null`. Populated if stream acquisition fails.
 *   `autostart`: A boolean attribute. If present, the UA will attempt to start the stream automatically as the element is added to the DOM and rendered (provided permissions are already granted).
 *   `onstream`: An `EventHandler` that fires when a hardware acquisition attempt completes successfully and populates the `stream` property.
-*   `onerror`: An `EventHandler` that fires when a stream acquisition attempt fails. To allow the element to carry detailed diagnostic info without bloating the main element interface, it is proposed that this event object carries a dedicated error payload containing, for example, a DOMException along with optional platform-specific diagnostic parameters.
+*   `onerror`: An `EventHandler` that fires when a stream acquisition attempt fails. See Error Handling below for details.
+*   `oncancel`: An `EventHandler` that fires when the user cancels or dismisses the permission prompt during acquisition.
 
 ### Constraints Configuration
 
@@ -130,31 +113,47 @@ Developers can specify `HTMLMediaStreamConstraints` to dictate the parameters of
 
 ```javascript
 const umElement = document.querySelector('usermedia');
-const videoEl = document.querySelector('video');
 
 // Configure constraints for combined audio/video capture
 umElement.setConstraints({
   video: { width: 1280 },
   audio: {}
 });
-
-// Handle successful stream acquisition
-umElement.addEventListener("stream", () => {
-  videoEl.srcObject = umElement.stream;
-});
-
-// Handle stream acquisition failure
-umElement.addEventListener("error", (event) => {
-  console.error("Combined stream acquisition failed:", event.detail?.exception.name);
-});
 ```
 
 ## User Journey & Interaction Model
 
 1.  Request State (Inactive): An element with no active associated `MediaStream` is in a request state. A User Gesture (click) triggers a permission prompt (if not already granted). Alternatively, if the `autostart` attribute is present when the element is rendered in the DOM, the UA will attempt to bypass the click requirement and automatically start the stream (provided permissions are already granted).
-2.  Acquisition: Upon grant, the UA implicitly executes a `getUserMedia` request using the element's configured constraints. The resulting track or stream is assigned to the `track` or `stream` property. If acquisition succeeds, the element fires the `stream` event and begins monitoring the resulting `MediaStreamTrack`s. If acquisition fails, the element fires the `error` event carrying detailed payload diagnostics.
-3.  Control State (Active for `<camera>` and `<microphone>` only): The element updates its internal UI (e.g., from "Use Camera" to "Mute Camera"). Subsequent clicks on `<camera>` or `<microphone>` elements will trigger the element's secondary activation steps, natively toggling the `enabled` property of all associated `MediaStreamTrack`s. The `<usermedia>` element skips this second-click behavior due to the complexity of managing potentially independent active/ended states for multiple audio and video tracks.
-4.  Track Monitoring: The element acts as an active monitor for its internal tracks or streams, observing their `enabled`, `muted`, and `ended` states (including manual `track.stop()` calls) to ensure its UI remains securely synchronized with the underlying hardware state. Any state changes will update the element's UI. If all tracks terminate, the element resets to its initial request state, and a subsequent click will fetch a new stream.
+2.  Acquisition (Success): Upon grant, the UA implicitly executes a `getUserMedia` request using the element's configured constraints. The resulting track or stream is assigned to the `track` or `stream` property, the element fires the `track` (or `stream`) event, and begins monitoring the resulting tracks.
+
+    ```javascript
+    const cameraEl = document.querySelector('camera');
+    const videoEl = document.querySelector('video');
+
+    // Handle successful track acquisition
+    cameraEl.addEventListener("track", () => {
+      const stream = new MediaStream([cameraEl.track]);
+      videoEl.srcObject = stream;
+    });
+    ```
+3.  Error Handling: If stream acquisition fails (e.g., due to platform denial or security error), the element populates its `error` property and fires an `error` event.
+
+    ```javascript
+    // Handle stream acquisition failure
+    cameraEl.addEventListener("error", () => {
+      console.error(`Camera acquisition failed: ${cameraEl.error?.name}`);
+    });
+    ```
+4.  User Cancellation: If the user decides not to proceed (for example dismisses or closes the permission prompt without granting or denying access), the element fires a `cancel` event.
+
+    ```javascript
+    // Handle prompt cancellation
+    cameraEl.addEventListener("cancel", () => {
+      console.log("Permission prompt was dismissed by the user.");
+    });
+    ```
+5.  Control State (Active for `<camera>` and `<microphone>` only): The element updates its internal UI (e.g., from "Use Camera" to "Mute Camera"). Subsequent clicks on `<camera>` or `<microphone>` elements will trigger the element's secondary activation steps, natively toggling the `enabled` property of all associated `MediaStreamTrack`s. The `<usermedia>` element skips this second-click behavior due to the complexity of managing potentially independent active/ended states for multiple audio and video tracks.
+6.  Track Monitoring: The element acts as an active monitor for its internal tracks or streams, observing their `enabled`, `muted`, and `ended` states (including manual `track.stop()` calls) to ensure its UI remains securely synchronized with the underlying hardware state. Any state changes will update the element's UI. If all tracks terminate, the element resets to its initial request state, and a subsequent click will fetch a new stream.
 
 ## Key Scenarios
 

--- a/media-capture-elements-explainer.md
+++ b/media-capture-elements-explainer.md
@@ -27,53 +27,165 @@ This document proposes a suite of targeted Media Capture Elements (`<usermedia>`
 *   Replacing `getUserMedia`: The `mediaDevices.getUserMedia` API remains the primary programmatic primitive. Media Capture Elements are designed to complement it by handling common UI-driven flows. In the future, we may add a parameter to indicate whether the `getUserMedia` request originated from a programmatic JS call or directly from a media capture element.
 *   Complete UI Customization: The shadow DOM/internal UI of these elements is strictly controlled by the UA to prevent clickjacking and ensure a trusted state representation. Complete visual overriding by the site is a non-goal for security reasons.
 
-## Proposed API
+## The `<camera>` HTML element
 
-### HTML Elements
+The `<camera>` element provides a dedicated UI for requesting and controlling access to a camera's video track. It renders as a camera text button or icon. After a successful grant, the element transitions to a trusted UI toggle for muting and unmuting the video stream.
 
-*   `<camera>`: Controls video-only capture. Renders as a camera text button or icon.
-*   `<microphone>`: Controls audio-only capture. Renders as a microphone text button or icon.
-*   `<usermedia>`: Controls combined audio and video capture.
-
-### IDL Definitions
+### WebIDL
 
 ```webidl
 [Exposed=Window]
 interface HTMLCameraElement : HTMLElement {
   [HTMLConstructor] constructor();
 
-  readonly attribute MediaStream? stream;
-  undefined setConstraints(MediaStreamConstraints constraints);
+  readonly attribute MediaStreamTrack? track;
+  undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
   readonly attribute any error;
 
+  attribute boolean autostart;
+
   attribute EventHandler onstream;
-  attribute EventHandler ontrackchanged;
+  attribute EventHandler ontrackchange;
 };
 HTMLCameraElement includes ActivationBlockersMixin;
+```
 
+### Attributes and Properties
+
+*   `track`: A read-only property that holds the associated `MediaStreamTrack` object (video). It is populated automatically upon successful user interaction.
+*   `autostart`: A boolean attribute. If present, the UA will attempt to start the stream automatically as the element is added to the DOM and rendered (provided permissions are already granted).
+*   `error`: A read-only property that holds a `DOMException` or `null`. Populated if the stream acquisition fails.
+*   `onstream`: An `EventHandler` that fires when a `getUserMedia` attempt finishes (either populating `track` or `error`).
+*   `ontrackchange`: An `EventHandler` that fires when the associated track's active/muted/ended state changes.
+*   `isValid`, `invalidReason`, `onvalidationstatuschange`: Provided by the `ActivationBlockersMixin` to protect against programmatic activation and clickjacking.
+
+### Constraints Configuration
+
+Developers can specify a `MediaTrackConstraintSet` to dictate the parameters of the underlying `getUserMedia` call. This is done imperatively via the `setConstraints()` method. If constraints are not set before the user interacts with the element, an empty default (`{}`) is used.
+
+**Constraint Filtering**: The UA applies a "constraint filter" before executing the `getUserMedia` call. Because the element's `setConstraints()` takes a `MediaTrackConstraintSet` directly (which contains no `audio` or `video` keys), the UA constructs a `MediaStreamConstraints` object where `audio` is forced to `false`, and `video` is set to the provided `MediaTrackConstraintSet`. Additionally, any required constraints (like `exact`, `min`, or `max`) are stripped to prevent the element from failing silently with an `OverconstrainedError` when the user interacts with it.
+
+### Example
+
+```html
+<!-- A camera element that will be configured via JavaScript -->
+<camera id="my-camera"></camera>
+<video id="camera-playback" autoplay playsinline></video>
+
+<script>
+  const cameraEl = document.getElementById('my-camera');
+  const videoEl = document.getElementById('camera-playback');
+
+  // The developer configures high-resolution video constraints for the camera element
+  cameraEl.setConstraints({
+    width: { ideal: 1920 }, height: { ideal: 1080 }
+  });
+
+  // Listen for the stream event which fires when acquisition finishes
+  cameraEl.addEventListener("stream", () => {
+    if (cameraEl.track) {
+      // Create a MediaStream from the track to attach to the video element
+      const stream = new MediaStream([cameraEl.track]);
+      videoEl.srcObject = stream;
+    } else if (cameraEl.error) {
+      console.error("Stream acquisition failed:", cameraEl.error);
+    }
+  });
+
+  // Observe the trackchange event to react to mute/unmute state changes
+  cameraEl.addEventListener("trackchange", () => {
+    console.log("Track active/muted/ended state changed");
+  });
+</script>
+```
+
+## The `<microphone>` HTML element
+
+The `<microphone>` element provides a dedicated UI for requesting and controlling access to a microphone's audio track. It renders as a microphone text button or icon. After a successful grant, the element transitions to a trusted UI toggle for muting and unmuting the audio stream.
+
+### WebIDL
+
+```webidl
 [Exposed=Window]
 interface HTMLMicrophoneElement : HTMLElement {
   [HTMLConstructor] constructor();
 
-  readonly attribute MediaStream? stream;
-  undefined setConstraints(MediaStreamConstraints constraints);
+  readonly attribute MediaStreamTrack? track;
+  undefined setConstraints(optional MediaTrackConstraintSet constraints = {});
   readonly attribute any error;
 
+  attribute boolean autostart;
+
   attribute EventHandler onstream;
-  attribute EventHandler ontrackchanged;
+  attribute EventHandler ontrackchange;
 };
 HTMLMicrophoneElement includes ActivationBlockersMixin;
+```
+
+### Attributes and Properties
+
+*   `track`: A read-only property that holds the associated `MediaStreamTrack` object (audio). It is populated automatically upon successful user interaction.
+*   `autostart`: A boolean attribute. If present, the UA will attempt to start the stream automatically as the element is added to the DOM and rendered (provided permissions are already granted).
+*   `error`: A read-only property that holds a `DOMException` or `null`. Populated if the stream acquisition fails.
+*   `onstream`: An `EventHandler` that fires when a `getUserMedia` attempt finishes (either populating `track` or `error`).
+*   `ontrackchange`: An `EventHandler` that fires when the associated track's active/muted/ended state changes.
+*   `isValid`, `invalidReason`, `onvalidationstatuschange`: Provided by the `ActivationBlockersMixin` to protect against programmatic activation and clickjacking.
+
+### Constraints Configuration
+
+Developers can specify a `MediaTrackConstraintSet` to dictate the parameters of the underlying `getUserMedia` call. This is done imperatively via the `setConstraints()` method. If constraints are not set before the user interacts with the element, an empty default (`{}`) is used.
+
+**Constraint Filtering**: The UA applies a "constraint filter" before executing the `getUserMedia` call. Because the element's `setConstraints()` takes a `MediaTrackConstraintSet` directly (which contains no `audio` or `video` keys), the UA constructs a `MediaStreamConstraints` object where `video` is forced to `false`, and `audio` is set to the provided `MediaTrackConstraintSet`. Additionally, any required constraints are stripped to prevent the element from failing silently with an `OverconstrainedError`.
+
+### Example
+
+```html
+<!-- A microphone element that will be configured via JavaScript -->
+<microphone id="my-microphone"></microphone>
+
+<script>
+  const micEl = document.getElementById('my-microphone');
+
+  // The developer configures audio constraints for the microphone element
+  micEl.setConstraints({
+    echoCancellation: true,
+    noiseSuppression: true
+  });
+
+  micEl.addEventListener("stream", () => {
+    if (micEl.track) {
+      console.log("Audio track acquired!");
+    } else if (micEl.error) {
+      console.error("Audio acquisition failed:", micEl.error);
+    }
+  });
+</script>
+```
+
+## The `<usermedia>` HTML element
+
+The `<usermedia>` element controls combined audio and video capture. Unlike `<camera>` and `<microphone>`, it does not natively transition into a per-track mute/unmute control upon grant due to the complexity of managing potentially independent active/ended states for multiple audio and video tracks. It primarily functions as a unified access broker.
+
+### WebIDL
+
+```webidl
+dictionary HTMLMediaStreamConstraints {
+  MediaTrackConstraintSet video;
+  MediaTrackConstraintSet audio;
+};
 
 [Exposed=Window]
 interface HTMLUserMediaElement : HTMLElement {
   [HTMLConstructor] constructor();
 
   readonly attribute MediaStream? stream;
-  undefined setConstraints(MediaStreamConstraints constraints);
+  undefined setConstraints(optional HTMLMediaStreamConstraints constraints = {});
   readonly attribute any error;
 
+  attribute boolean autostart;
+
   attribute EventHandler onstream;
-  attribute EventHandler ontrackchanged;
+  attribute EventHandler ontrackchange;
 };
 HTMLUserMediaElement includes ActivationBlockersMixin;
 ```
@@ -82,59 +194,23 @@ HTMLUserMediaElement includes ActivationBlockersMixin;
 
 *   `stream`: A read-only property that holds the associated `MediaStream` object. It is populated automatically upon successful user interaction.
 *   `autostart`: A boolean attribute. If present, the UA will attempt to start the stream automatically as the element is added to the DOM and rendered (provided permissions are already granted).
-*   `error`: A read-only property that holds a `DOMException`, an `OverConstrainedError` or `null`. Populated if the stream acquisition fails.
+*   `error`: A read-only property that holds a `DOMException` or `null`. Populated if the stream acquisition fails.
 *   `onstream`: An `EventHandler` that fires when a `getUserMedia` attempt finishes (either populating `stream` or `error`).
-*   `ontrackchanged`: An `EventHandler` that fires when the associated tracks' active/muted/ended states change.
+*   `ontrackchange`: An `EventHandler` that fires when the associated tracks' active/muted/ended states change.
 *   `isValid`, `invalidReason`, `onvalidationstatuschange`: Provided by the `ActivationBlockersMixin` to protect against programmatic activation and clickjacking.
 
 ### Constraints Configuration
 
-Developers can specify `MediaStreamConstraints` to dictate the parameters of the underlying `getUserMedia` call. This is done imperatively via the `setConstraints()` method. If constraints are not set before the user interacts with the element, a secure default (e.g., `{audio:true, video:true}` for `<usermedia>`) is used.
+Developers can specify `HTMLMediaStreamConstraints` to dictate the parameters of the underlying `getUserMedia` call. This is done imperatively via the `setConstraints()` method. If constraints are not set before the user interacts with the element, a secure default (`{audio:{}, video:{}}`) is used.
 
-**Constraint Filtering**: To maintain security and semantic accuracy, the UA applies a "constraint filter" before executing the `getUserMedia` call. This ensures that an element only requests the media type it was designed for, preventing developers from mistakenly (or maliciously) requesting audio via a `<camera>` element or video via a `<microphone>` element. 
+**Constraint Filtering**: The UA applies a "constraint filter" before executing the `getUserMedia` call. For `<usermedia>`, the UA constructs a `MediaStreamConstraints` object by extracting the `audio` and `video` `MediaTrackConstraintSet`s from the provided `HTMLMediaStreamConstraints`. If either is omitted, an empty constraint set (`{}`) is substituted, ensuring both audio and video are always requested. Additionally, any required constraints are stripped to prevent silent `OverconstrainedError` failures.
 
-*   `<usermedia>` passes through both `audio` and `video` constraints.
-*   `<camera>` forces `audio: false` and only passes through `video` constraints.
-*   `<microphone>` forces `video: false` and only passes through `audio` constraints.
-
-**Example of Constraint Filtering:**
-```javascript
-const cameraEl = document.createElement('camera');
-
-// The developer attempts to request both audio and high-resolution video
-cameraEl.setConstraints({
-  audio: true, 
-  video: { width: { ideal: 1920 }, height: { ideal: 1080 } }
-});
-
-// Under the hood, the UA applies the constraint filter for <camera>.
-// The resulting `getUserMedia` call executed by the UA will look like this:
-// navigator.mediaDevices.getUserMedia({
-//   audio: false, // The filter strictly overrides the developer's 'true' request
-//   video: { width: { ideal: 1920 }, height: { ideal: 1080 } }
-// });
-```
-
-## User Journey & Interaction Model
-
-1.  Request State (Inactive): An element with no active associated `MediaStream` is in a request state. A User Gesture (click) triggers a permission prompt (if not already granted). Alternatively, if the `autostart` attribute is present when the element is rendered in the DOM, the UA will attempt to bypass the click requirement and automatically start the stream (provided permissions are already granted).
-2.  Acquisition: Upon grant, the UA implicitly executes a `getUserMedia` request using the element's configured constraints. The resulting `MediaStream` is assigned to the `stream` property. If acquisition fails, the `error` property is populated. The element fires the `stream` event and begins monitoring the resulting `MediaStreamTrack`s.
-3.  Control State (Active for `<camera>` and `<microphone>` only): The element updates its internal UI (e.g., from "Use Camera" to "Mute Camera"). Subsequent clicks on `<camera>` or `<microphone>` elements will trigger the element's secondary activation steps, natively toggling the `enabled` property of all associated `MediaStreamTrack`s. The `<usermedia>` element skips this second-click behavior due to the complexity of managing potentially independent active/ended states for multiple audio and video tracks.
-4.  Track Monitoring: The element acts as an active monitor for its internal `stream`, observing the `enabled`, `muted`, and `ended` states (including manual `track.stop()` calls) of the associated tracks to ensure its UI remains securely synchronized with the underlying hardware state. Any state changes will update the element's UI and fire the `trackchanged` event. If all tracks terminate (i.e. the stream becomes inactive), the element resets to its initial request state, and a subsequent click will fetch a new stream.
-
-## Key Scenarios
-
-*   Contextual Permission Recovery: A user who previously denied microphone access sees a `<microphone>` element with a warning badge. Clicking it opens a UA-provided dialogue explaining the blocked state and allowing immediate recovery within the page context, without digging through browser settings.
-*   Seamless Re-entry (Autostart): A user accesses a known meeting room where they previously granted camera and microphone access. The web page renders `<usermedia autostart></usermedia>`. The UA immediately acquires the stream and fires the `stream` event without waiting for the user to click the element, allowing immediate video playback.
-*   Conferencing entry: A user clicks a `<usermedia>` button in a meeting lobby. The browser handles the prompt and the stream acquisition. The developer observes the `stream` property and attaches it to a `<video>` tag, all without needing to write complex `getUserMedia` logic.
-
-## Example
+### Example
 
 ```html
-<video id="stream-playback" autoplay playsinline></video> 
-
 <!-- A usermedia element that will be configured via JavaScript -->
 <usermedia id="my-usermedia"></usermedia>
+<video id="stream-playback" autoplay playsinline></video>
 
 <script>
   const umElement = document.getElementById("my-usermedia");
@@ -143,7 +219,7 @@ cameraEl.setConstraints({
   // Configure specific video bounds using setConstraints()
   umElement.setConstraints({
     video: { width: { ideal: 1280 } },
-    audio: true
+    audio: {}
   });
 
   // Listen for the stream event which fires when acquisition finishes
@@ -155,12 +231,25 @@ cameraEl.setConstraints({
     }
   });
 
-  // Observe the trackchanged event to react to mute/unmute state changes
-  umElement.addEventListener("trackchanged", () => {
+  // Observe the trackchange event to react to mute/unmute state changes
+  umElement.addEventListener("trackchange", () => {
     console.log("Track active/muted/ended state changed");
   });
 </script>
 ```
+
+## User Journey & Interaction Model
+
+1.  Request State (Inactive): An element with no active associated `MediaStream` is in a request state. A User Gesture (click) triggers a permission prompt (if not already granted). Alternatively, if the `autostart` attribute is present when the element is rendered in the DOM, the UA will attempt to bypass the click requirement and automatically start the stream (provided permissions are already granted).
+2.  Acquisition: Upon grant, the UA implicitly executes a `getUserMedia` request using the element's configured constraints. The resulting `MediaStream` is assigned to the `stream` property. If acquisition fails, the `error` property is populated. The element fires the `stream` event and begins monitoring the resulting `MediaStreamTrack`s.
+3.  Control State (Active for `<camera>` and `<microphone>` only): The element updates its internal UI (e.g., from "Use Camera" to "Mute Camera"). Subsequent clicks on `<camera>` or `<microphone>` elements will trigger the element's secondary activation steps, natively toggling the `enabled` property of all associated `MediaStreamTrack`s. The `<usermedia>` element skips this second-click behavior due to the complexity of managing potentially independent active/ended states for multiple audio and video tracks.
+4.  Track Monitoring: The element acts as an active monitor for its internal `stream`, observing the `enabled`, `muted`, and `ended` states (including manual `track.stop()` calls) of the associated tracks to ensure its UI remains securely synchronized with the underlying hardware state. Any state changes will update the element's UI and fire the `trackchange` event. If all tracks terminate (i.e. the stream becomes inactive), the element resets to its initial request state, and a subsequent click will fetch a new stream.
+
+## Key Scenarios
+
+*   Contextual Permission Recovery: A user who previously denied microphone access sees a `<microphone>` element with a warning badge. Clicking it opens a UA-provided dialogue explaining the blocked state and allowing immediate recovery within the page context, without digging through browser settings.
+*   Seamless Re-entry (Autostart): A user accesses a known meeting room where they previously granted camera and microphone access. The web page renders `<usermedia autostart></usermedia>`. The UA immediately acquires the stream and fires the `stream` event without waiting for the user to click the element, allowing immediate video playback.
+*   Conferencing entry: A user clicks a `<usermedia>` button in a meeting lobby. The browser handles the prompt and the stream acquisition. The developer observes the `stream` property and attaches it to a `<video>` tag, all without needing to write complex `getUserMedia` logic.
 
 ## Privacy & Security Considerations
 
@@ -171,4 +260,5 @@ cameraEl.setConstraints({
 ## Stakeholder Feedback / Opposition
 
 - Chromium: Positive. Implementing the MVP; previous Origin Trials showed significant improvements for user experience and the permission granting flow.
-- Mozilla and WebKit (Apple): Engaged in discussions. Feedback provided via standard positions ([#1245](https://github.com/mozilla/standards-positions/issues/1245)) and WICG issues.
+- Mozilla and WebKit (Apple): Engaged in discussions. Feedback provided via standard positions ([#1245](https://github.com/mozilla/standards-positions/issues/1245)) and WICG issues ([#62](https://github.com/WICG/PEPC/issues/62)).
+

--- a/media-capture-elements-explainer.md
+++ b/media-capture-elements-explainer.md
@@ -1,0 +1,174 @@
+# Media Capture Elements: `<usermedia>`, `<camera>`, and `<microphone>`
+
+## Authors:
+
+- Daniel Vogelheim (Google LLC)
+- Minh Le (Google LLC)
+- Thomas Nguyen (Google LLC)
+
+## Introduction
+
+The web permission model is shifting from passive permission control to active Capability Elements. Building on the foundations of the Page-Embedded Permission Control (PEPC) initiative, these specialized Capability elements evolve the user experience from a simple "Allow/Deny" toggle into a direct controller for web capabilities.
+
+Rather than serving as a static status indicator, a Capability Element acts as a functional action broker. It streamlines the entire lifecycle: establishing a trusted signal of intent, managing the permission flow, and delivering the resulting data or media stream directly to the application. This shift reduces developer friction, eliminates "permission holes," and provides users with a consistent, browser-controlled interface for hardware like cameras and microphones.
+
+This document proposes a suite of targeted Media Capture Elements (`<usermedia>`, `<camera>`, and `<microphone>`). They move beyond acting merely as permission gatekeepers to serving as data mediators: handling consent, fetching the `MediaStream`, delivering it to the site, and persisting as a stateful, trusted UI control for toggling media tracks.
+
+## Goals
+
+*   Data Mediator and Action Broker: The elements handle the entire acquisition flow: obtaining user consent, executing the underlying `getUserMedia` request, and exposing the resulting `MediaStream` directly, often eliminating the need for separate JavaScript API boilerplate.
+*   Stateful Media Capture Control: Elements act as integrated UI components. Following a permission grant, the element transitions from a "request" state to a "control" state. For `<camera>` and `<microphone>`, this provides a browser-enforced, trusted UI toggle for muting and unmuting the stream. All elements act as strict monitors of their assigned track's states, natively reverting to the "request" state if the underlying tracks are fully terminated.
+*   Reduced Friction & Trusted Intent: Establish a "trusted signal of intent" driven by explicit User Gestures on a browser-controlled element, allowing developers to offer users an option to use the grant and use the capability in context.
+*   Seamless In-Page Recovery: Similar to and inheriting concepts from the `<permission>` element, this resolves the "permission hole" by providing an in-page flow to re-enable access if the user previously denied it, avoiding the need for users to navigate complex, UA-specific browser settings.
+*   Specific vs. Generic Tags: Replace the generic `<permission>` element with targeted, semantic elements (`<camera>`, `<microphone>`, `<usermedia>`). This allows for UA-tailored UI, specific IDL attributes, and distinct security/privacy models tailored to the specific hardware media capture capability.
+
+## Non-goals
+
+*   Replacing `getUserMedia`: The `mediaDevices.getUserMedia` API remains the primary programmatic primitive. Media Capture Elements are designed to complement it by handling common UI-driven flows. In the future, we may add a parameter to indicate whether the `getUserMedia` request originated from a programmatic JS call or directly from a media capture element.
+*   Complete UI Customization: The shadow DOM/internal UI of these elements is strictly controlled by the UA to prevent clickjacking and ensure a trusted state representation. Complete visual overriding by the site is a non-goal for security reasons.
+
+## Proposed API
+
+### HTML Elements
+
+*   `<camera>`: Controls video-only capture. Renders as a camera text button or icon.
+*   `<microphone>`: Controls audio-only capture. Renders as a microphone text button or icon.
+*   `<usermedia>`: Controls combined audio and video capture.
+
+### IDL Definitions
+
+```webidl
+[Exposed=Window]
+interface HTMLCameraElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  readonly attribute MediaStream? stream;
+  undefined setConstraints(MediaStreamConstraints constraints);
+  readonly attribute any error;
+
+  attribute EventHandler onstream;
+  attribute EventHandler ontrackchanged;
+};
+HTMLCameraElement includes ActivationBlockersMixin;
+
+[Exposed=Window]
+interface HTMLMicrophoneElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  readonly attribute MediaStream? stream;
+  undefined setConstraints(MediaStreamConstraints constraints);
+  readonly attribute any error;
+
+  attribute EventHandler onstream;
+  attribute EventHandler ontrackchanged;
+};
+HTMLMicrophoneElement includes ActivationBlockersMixin;
+
+[Exposed=Window]
+interface HTMLUserMediaElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  readonly attribute MediaStream? stream;
+  undefined setConstraints(MediaStreamConstraints constraints);
+  readonly attribute any error;
+
+  attribute EventHandler onstream;
+  attribute EventHandler ontrackchanged;
+};
+HTMLUserMediaElement includes ActivationBlockersMixin;
+```
+
+### Attributes and Properties
+
+*   `stream`: A read-only property that holds the associated `MediaStream` object. It is populated automatically upon successful user interaction.
+*   `autostart`: A boolean attribute. If present, the UA will attempt to start the stream automatically as the element is added to the DOM and rendered (provided permissions are already granted).
+*   `error`: A read-only property that holds a `DOMException`, an `OverConstrainedError` or `null`. Populated if the stream acquisition fails.
+*   `onstream`: An `EventHandler` that fires when a `getUserMedia` attempt finishes (either populating `stream` or `error`).
+*   `ontrackchanged`: An `EventHandler` that fires when the associated tracks' active/muted/ended states change.
+*   `isValid`, `invalidReason`, `onvalidationstatuschange`: Provided by the `ActivationBlockersMixin` to protect against programmatic activation and clickjacking.
+
+### Constraints Configuration
+
+Developers can specify `MediaStreamConstraints` to dictate the parameters of the underlying `getUserMedia` call. This is done imperatively via the `setConstraints()` method. If constraints are not set before the user interacts with the element, a secure default (e.g., `{audio:true, video:true}` for `<usermedia>`) is used.
+
+**Constraint Filtering**: To maintain security and semantic accuracy, the UA applies a "constraint filter" before executing the `getUserMedia` call. This ensures that an element only requests the media type it was designed for, preventing developers from mistakenly (or maliciously) requesting audio via a `<camera>` element or video via a `<microphone>` element. 
+
+*   `<usermedia>` passes through both `audio` and `video` constraints.
+*   `<camera>` forces `audio: false` and only passes through `video` constraints.
+*   `<microphone>` forces `video: false` and only passes through `audio` constraints.
+
+**Example of Constraint Filtering:**
+```javascript
+const cameraEl = document.createElement('camera');
+
+// The developer attempts to request both audio and high-resolution video
+cameraEl.setConstraints({
+  audio: true, 
+  video: { width: { ideal: 1920 }, height: { ideal: 1080 } }
+});
+
+// Under the hood, the UA applies the constraint filter for <camera>.
+// The resulting `getUserMedia` call executed by the UA will look like this:
+// navigator.mediaDevices.getUserMedia({
+//   audio: false, // The filter strictly overrides the developer's 'true' request
+//   video: { width: { ideal: 1920 }, height: { ideal: 1080 } }
+// });
+```
+
+## User Journey & Interaction Model
+
+1.  Request State (Inactive): An element with no active associated `MediaStream` is in a request state. A User Gesture (click) triggers a permission prompt (if not already granted). Alternatively, if the `autostart` attribute is present when the element is rendered in the DOM, the UA will attempt to bypass the click requirement and automatically start the stream (provided permissions are already granted).
+2.  Acquisition: Upon grant, the UA implicitly executes a `getUserMedia` request using the element's configured constraints. The resulting `MediaStream` is assigned to the `stream` property. If acquisition fails, the `error` property is populated. The element fires the `stream` event and begins monitoring the resulting `MediaStreamTrack`s.
+3.  Control State (Active for `<camera>` and `<microphone>` only): The element updates its internal UI (e.g., from "Use Camera" to "Mute Camera"). Subsequent clicks on `<camera>` or `<microphone>` elements will trigger the element's secondary activation steps, natively toggling the `enabled` property of all associated `MediaStreamTrack`s. The `<usermedia>` element skips this second-click behavior due to the complexity of managing potentially independent active/ended states for multiple audio and video tracks.
+4.  Track Monitoring: The element acts as an active monitor for its internal `stream`, observing the `enabled`, `muted`, and `ended` states (including manual `track.stop()` calls) of the associated tracks to ensure its UI remains securely synchronized with the underlying hardware state. Any state changes will update the element's UI and fire the `trackchanged` event. If all tracks terminate (i.e. the stream becomes inactive), the element resets to its initial request state, and a subsequent click will fetch a new stream.
+
+## Key Scenarios
+
+*   Contextual Permission Recovery: A user who previously denied microphone access sees a `<microphone>` element with a warning badge. Clicking it opens a UA-provided dialogue explaining the blocked state and allowing immediate recovery within the page context, without digging through browser settings.
+*   Seamless Re-entry (Autostart): A user accesses a known meeting room where they previously granted camera and microphone access. The web page renders `<usermedia autostart></usermedia>`. The UA immediately acquires the stream and fires the `stream` event without waiting for the user to click the element, allowing immediate video playback.
+*   Conferencing entry: A user clicks a `<usermedia>` button in a meeting lobby. The browser handles the prompt and the stream acquisition. The developer observes the `stream` property and attaches it to a `<video>` tag, all without needing to write complex `getUserMedia` logic.
+
+## Example
+
+```html
+<video id="stream-playback" autoplay playsinline></video> 
+
+<!-- A usermedia element that will be configured via JavaScript -->
+<usermedia id="my-usermedia"></usermedia>
+
+<script>
+  const umElement = document.getElementById("my-usermedia");
+  const videoEl = document.getElementById("stream-playback");
+
+  // Configure specific video bounds using setConstraints()
+  umElement.setConstraints({
+    video: { width: { ideal: 1280 } },
+    audio: true
+  });
+
+  // Listen for the stream event which fires when acquisition finishes
+  umElement.addEventListener("stream", () => {
+    if (umElement.stream) {
+      videoEl.srcObject = umElement.stream;
+    } else if (umElement.error) {
+      console.error("Stream acquisition failed:", umElement.error);
+    }
+  });
+
+  // Observe the trackchanged event to react to mute/unmute state changes
+  umElement.addEventListener("trackchanged", () => {
+    console.log("Track active/muted/ended state changed");
+  });
+</script>
+```
+
+## Privacy & Security Considerations
+
+*   Implicit Stream Activation: Unlike the legacy `<permission>` element which merely gated access, Media Capture Elements automatically trigger device hardware and indicator lights (e.g., the camera LED) upon grant. Future iterations of this specification may need to introduce additional features to support initializing streams in an explicitly disabled state to mitigate privacy concerns when immediate activation is unexpected. The exact feasibility and shape of such additions are currently under investigation. 
+*   Constraint Fingerprinting: Allowing sites to pass highly specific `MediaStreamConstraints` via the element exposes the same device fingerprinting vectors as the raw `getUserMedia` API. UAs must apply the same fingerprinting mitigations (e.g., fuzzying exact constraints, restricting access to `deviceId` until permission is granted) to the declarative constraints as they do to imperative JS calls.
+*   Trusted UI vs. Clickjacking: Because these elements control sensitive hardware states (mute/unmute), their rendering must be strictly limited from the host page's CSS layout interference to prevent clickjacking or "fake element" attacks. The elements must be implemented using secure, closed UA Shadow DOMs, and pointer events must be rigorously validated as trusted User Gestures.
+
+## Stakeholder Feedback / Opposition
+
+- Chromium: Positive. Implementing the MVP; previous Origin Trials showed significant improvements for user experience and the permission granting flow.
+- Mozilla and WebKit (Apple): Engaged in discussions. Feedback provided via standard positions ([#1245](https://github.com/mozilla/standards-positions/issues/1245)) and WICG issues.


### PR DESCRIPTION
This PR introduces the initial specs and explainer for Media Capture Elements: `<usermedia>`, `<camera>`, and `<microphone>`.

Changes in this CL:
* Explainer (`media-capture-elements-explainer.md`): High level API design.
* IDL Definitions (`index.html`): Adds `HTMLUserMediaElement`, `HTMLCameraElement`, and `HTMLMicrophoneElement`, utilizing `ActivationBlockersMixin`, including attributes & events.

Related link discussions:
* [TAG Design Review #1218](https://github.com/w3ctag/design-reviews/issues/1218)
* [Discussing Thread](https://github.com/WICG/PEPC/issues/62)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tungnh28/mediacapture-extensions/pull/168.html" title="Last updated on May 27, 2026, 10:35 AM UTC (fab1a74)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-extensions/168/57adf01...tungnh28:fab1a74.html" title="Last updated on May 27, 2026, 10:35 AM UTC (fab1a74)">Diff</a>